### PR TITLE
feat(sdk): GuestGroup resource, guest_group relation, and availability guest_code

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,19 @@ const { data } = await new GuestManager('event-uuid').checkin('guest-manager-cod
 // And all other methods: createCompanion, archive, restore, delete, createRecommendation, getAttachments, getAttachmentSignedUrl
 ```
 
+### GuestGroup methods
+
+#### List all guest groups
+
+Returns the array of guest groups directly (unwrapped). Each group's `name` is a locale→string map.
+
+```javascript
+import { GuestGroup } from '@airlst/sdk'
+
+const guestGroups = await new GuestGroup('event-uuid').list()
+// [{ id: '...', name: { 'en-GB': 'VIP', 'de-DE': 'VIP' } }, ...]
+```
+
 ### Email Template methods
 
 #### Retrieve all email templates for the event
@@ -323,7 +336,9 @@ import { Bookable } from '@airlst/sdk'
 
 const { data } = await new Bookable('event-uuid').listAvailabilities('bookable-group-uuid', 'bookable-object-uuid', {
   start_date: '2025-01-02',
-  end_date: '2025-02-03'
+  end_date: '2025-02-03',
+  // Optional: resolve the guest's group to compute guest-specific remaining capacity
+  guest_code: 'guest-code'
 })
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airlst/sdk",
-  "version": "0.0.23",
+  "version": "0.0.24-beta",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/airlst/sdk-js.git"

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,20 +3,23 @@ import { EmailTemplate } from './resources/EmailTemplate'
 import { Event } from './resources/Event'
 import { Guest } from './resources/Guest'
 import { GuestManager } from './resources/GuestManager'
+import { GuestGroup } from './resources/GuestGroup'
 import { Contact } from './resources/Contact'
 import { Bookable } from './resources/Bookable'
 import { QueryBuilder, QueryParameters } from './utils/QueryBuilder'
-import { GuestManagerInterface } from './interfaces'
+import { GuestManagerInterface, GuestGroupInterface } from './interfaces'
 
 export {
   Api,
   Event,
   Guest,
   GuestManager,
+  GuestGroup,
   EmailTemplate,
   Contact,
   Bookable,
   QueryBuilder,
   QueryParameters,
   GuestManagerInterface,
+  GuestGroupInterface,
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -14,16 +14,28 @@ interface LocaleInterface {
   label: string
 }
 
+export interface GuestGroupInterface {
+  id: string
+  name: {
+    [locale: string]: string
+  }
+}
+
 export interface GuestInterface {
   code: string
   role: string
   status: string
   extended_fields: object
+  guest_group: GuestGroupInterface | null
   booking: BookingInterface
   contact: ContactInterface
   files: Array<AttachmentInterface>
   reservations: Array<ReservationInterface>
   guest_managers: Array<GuestManagerInterface>
+  main_guest?: GuestInterface
+  companion_guests?: Array<GuestInterface>
+  recommended_by?: GuestInterface
+  recommended_guests?: Array<GuestInterface>
 }
 
 export interface GuestManagerInterface

--- a/src/resources/Bookable.ts
+++ b/src/resources/Bookable.ts
@@ -86,6 +86,7 @@ interface ListBookablesResponseInterface {
 interface ListAvailabilitiesInterface {
   start_date: string
   end_date: string
+  guest_code?: string
 }
 
 interface ListAvailabilitiesResponseInterface {

--- a/src/resources/GuestGroup.ts
+++ b/src/resources/GuestGroup.ts
@@ -1,0 +1,18 @@
+import { Api } from '../Api'
+import { GuestGroupInterface } from '../interfaces'
+
+export const GuestGroup = class {
+  public eventId: string
+
+  constructor(eventId: string) {
+    this.eventId = eventId
+  }
+
+  public async list(): Promise<Array<GuestGroupInterface>> {
+    const { data } = await Api.sendRequest(
+      `/events/${this.eventId}/guest-groups`,
+    )
+
+    return data.guest_groups
+  }
+}

--- a/tests/resources/Bookable.spec.ts
+++ b/tests/resources/Bookable.spec.ts
@@ -46,6 +46,28 @@ test('listAvailabilities()', async () => {
   )
 })
 
+test('listAvailabilities() with guest_code', async () => {
+  const requestBody = {
+    start_date: 'start-date',
+    end_date: 'end-date',
+    guest_code: 'ABCD1234',
+  }
+  await bookable.listAvailabilities(
+    'bookable-group-uuid',
+    'bookable-object-uuid',
+    requestBody,
+  )
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith(
+    '/events/event-uuid/bookables/groups/bookable-group-uuid/objects/bookable-object-uuid/availability',
+    {
+      method: 'post',
+      body: JSON.stringify(requestBody),
+    },
+  )
+})
+
 test('createReservation()', async () => {
   const requestBody = {
     guest_code: 'ABC123',

--- a/tests/resources/GuestGroup.spec.ts
+++ b/tests/resources/GuestGroup.spec.ts
@@ -1,0 +1,24 @@
+import { afterEach, test, expect, vi } from 'vitest'
+import { Api, GuestGroup } from '../../src'
+
+const apiMock = (Api.sendRequest = vi.fn())
+
+const guestGroup = new GuestGroup('event-uuid')
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+test('list()', async () => {
+  const guestGroups = [
+    { id: 'group-1', name: { 'en-GB': 'VIP', 'de-DE': 'VIP' } },
+    { id: 'group-2', name: { 'en-GB': 'Press', 'de-DE': 'Presse' } },
+  ]
+  apiMock.mockResolvedValue({ data: { guest_groups: guestGroups } })
+
+  const result = await guestGroup.list()
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith('/events/event-uuid/guest-groups')
+  expect(result).toStrictEqual(guestGroups)
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,7 +3,8 @@ import { defineConfig } from 'vite'
 export default defineConfig({
   test: {
     setupFiles: 'testSetup.js',
-    include: ['tests/**/*.{test,spec}.ts']
+    include: ['tests/**/*.{test,spec}.ts'],
+    clearMocks: true
   },
 })
 


### PR DESCRIPTION
## What

Exposes three public Event API additions in `@airlst/sdk`, plus a fix for the test suite.

### 1. New `GuestGroup` resource
- `src/resources/GuestGroup.ts` — event-scoped class (`constructor(eventId)`), `list()` hits `GET /events/{event}/guest-groups` and **unwraps** `data.guest_groups`, returning `Promise<GuestGroupInterface[]>`.
- `GuestGroupInterface { id: string; name: { [locale]: string } }` — `name` is a locale→string translations map.
- Exported `GuestGroup` and `GuestGroupInterface` from `index.ts`.

### 2. `guest_group` relation on guests
- Added `guest_group: GuestGroupInterface | null` to `GuestInterface`.
- `GuestManagerInterface` inherits it automatically via its existing `Omit<GuestInterface, 'guest_managers'>`.
- Modeled the previously-absent nested guest relations (`main_guest`, `companion_guests`, `recommended_by`, `recommended_guests`) as recursive `GuestInterface` so they carry `guest_group` too.

### 3. `guest_code` on `listAvailabilities`
- Added optional `guest_code?: string` to the request body type. The body is already forwarded verbatim, so this is a type-only change. The API resolves it to the guest's group for capacity; no response change.

### Test fix (separate commit)
The existing suite had 31 pre-existing failures: specs assign a module-level `Api.sendRequest = vi.fn()` and cleaned up with `vi.restoreAllMocks()`, which only restores `vi.spyOn` spies — not a manually-assigned `vi.fn()`. Call history accumulated across tests, breaking `toHaveBeenCalledTimes` assertions. Enabled `clearMocks: true` in `vite.config.js` so history resets before each test.

## Why

Public API gained guest groups, per-guest group membership, and guest-scoped availability capacity; the SDK must expose them with correct types.

## Notes for reviewer
- `name` is intentionally a `{ [locale]: string }` map, not a plain string.
- Interface named `GuestGroupInterface` (not `GuestGroup`) to match the codebase's `Interface` suffix convention and avoid colliding with the exported resource class `GuestGroup`.
- `AvailabilityInterface` left untouched per spec ("no response change") — note it does not currently declare `guest_group_id`; flag if you want the availability response type fleshed out.
- The temporary `openapi.yml` used to source these changes is intentionally **not** committed.

## Verification
- `yarn lint` — clean
- `npx tsc --noEmit --skipLibCheck` — types OK (plain `tsc` is blocked by a pre-existing `@types/chai` resolution error, unrelated to this change)
- `npx vitest run` — **46/46 passing across 8 files**

🤖 Generated with [Claude Code](https://claude.com/claude-code)