### PR TITLE
feat(bookables): add carrier order endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,3 +366,53 @@ import { Bookable } from '@airlst/sdk'
 
 await new Bookable('event-uuid').deleteReservation('guest-code', 'reservation-uuid')
 ```
+
+#### Get or create a booking's CART carrier order
+
+```javascript
+import { Bookable } from '@airlst/sdk'
+
+const { data } = await new Bookable('event-uuid').createOrder({
+  booking_id: 'booking-uuid'
+})
+```
+
+#### Get list of a booking's CART carrier orders
+
+```javascript
+import { Bookable } from '@airlst/sdk'
+
+const { data } = await new Bookable('event-uuid').listOrders('booking-uuid')
+```
+
+#### Show a carrier order with its line items and add-on reservations
+
+```javascript
+import { Bookable } from '@airlst/sdk'
+
+const { data } = await new Bookable('event-uuid').getOrder('order-uuid')
+```
+
+#### Add an add-on allocation line item to a carrier order
+
+```javascript
+import { Bookable } from '@airlst/sdk'
+
+const { data } = await new Bookable('event-uuid').addOrderLineItem('order-uuid', {
+  guest_code: 'guest-code',
+  addon_id: 'addon-uuid',
+  // Required unless the add-on has a FIXED availability type
+  start_at: '2026-06-03',
+  end_at: '2026-06-06',
+  quantity: 1
+})
+// data.reservation_ids => ['reservation-uuid', ...]
+```
+
+#### Delete an add-on allocation line item and release its contingent
+
+```javascript
+import { Bookable } from '@airlst/sdk'
+
+await new Bookable('event-uuid').deleteOrderLineItem('order-uuid', 'line-item-uuid')
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airlst/sdk",
-  "version": "0.0.24-beta",
+  "version": "0.0.24-beta1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/airlst/sdk-js.git"

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,12 @@ import { GuestGroup } from './resources/GuestGroup'
 import { Contact } from './resources/Contact'
 import { Bookable } from './resources/Bookable'
 import { QueryBuilder, QueryParameters } from './utils/QueryBuilder'
-import { GuestManagerInterface, GuestGroupInterface } from './interfaces'
+import {
+  GuestManagerInterface,
+  GuestGroupInterface,
+  OrderInterface,
+  OrderLineItemInterface,
+} from './interfaces'
 
 export {
   Api,
@@ -22,4 +27,6 @@ export {
   QueryParameters,
   GuestManagerInterface,
   GuestGroupInterface,
+  OrderInterface,
+  OrderLineItemInterface,
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -135,6 +135,24 @@ export interface ReservationInterface {
   bookable: CarBookableInterface
 }
 
+export interface OrderInterface {
+  id: string
+  status: string
+  line_items: Array<OrderLineItemInterface>
+  reservations: Array<ReservationInterface>
+  created_at: string
+  updated_at: string
+}
+
+export interface OrderLineItemInterface {
+  id: string
+  addon_id: string
+  guest_code: string
+  start_at: string | null
+  end_at: string | null
+  quantity: number
+}
+
 export interface AvailabilityInterface {
   starts_at: string
   ends_at: string

--- a/src/resources/Bookable.ts
+++ b/src/resources/Bookable.ts
@@ -3,6 +3,7 @@ import {
   AvailabilityInterface,
   BookableGroupInterface,
   CarBookableInterface,
+  OrderInterface,
   ReservationInterface,
 } from '../interfaces'
 
@@ -63,6 +64,60 @@ export const Bookable = class {
       },
     )
   }
+
+  public async createOrder(
+    body: CreateOrderInterface,
+  ): Promise<CreateOrderResponseInterface> {
+    return await Api.sendRequest(`/events/${this.eventId}/bookables/orders`, {
+      method: 'post',
+      body: JSON.stringify(body),
+    })
+  }
+
+  public async listOrders(
+    bookingId: string,
+  ): Promise<ListOrdersResponseInterface> {
+    const queryString = new URLSearchParams({
+      booking_id: bookingId,
+    }).toString()
+
+    return await Api.sendRequest(
+      `/events/${this.eventId}/bookables/orders?${queryString}`,
+    )
+  }
+
+  public async getOrder(
+    orderUuid: string,
+  ): Promise<ShowOrderResponseInterface> {
+    return await Api.sendRequest(
+      `/events/${this.eventId}/bookables/orders/${orderUuid}`,
+    )
+  }
+
+  public async addOrderLineItem(
+    orderUuid: string,
+    body: AddOrderLineItemInterface,
+  ): Promise<AddOrderLineItemResponseInterface> {
+    return await Api.sendRequest(
+      `/events/${this.eventId}/bookables/orders/${orderUuid}/line-items`,
+      {
+        method: 'post',
+        body: JSON.stringify(body),
+      },
+    )
+  }
+
+  public async deleteOrderLineItem(
+    orderUuid: string,
+    lineItemUuid: string,
+  ): Promise<void> {
+    await Api.sendRequest(
+      `/events/${this.eventId}/bookables/orders/${orderUuid}/line-items/${lineItemUuid}`,
+      {
+        method: 'delete',
+      },
+    )
+  }
 }
 
 interface ListGroupsResponseInterface {
@@ -107,5 +162,35 @@ interface CreateReservationInterface {
 interface CreateReservationResponseInterface {
   data: {
     reservation: ReservationInterface
+  }
+}
+
+interface CreateOrderInterface {
+  booking_id: string
+}
+
+interface AddOrderLineItemInterface {
+  guest_code: string
+  addon_id: string
+  start_at?: string
+  end_at?: string
+  quantity: number
+}
+
+interface CreateOrderResponseInterface {
+  data: OrderInterface
+}
+
+interface ListOrdersResponseInterface {
+  data: Array<OrderInterface>
+}
+
+interface ShowOrderResponseInterface {
+  data: OrderInterface
+}
+
+interface AddOrderLineItemResponseInterface {
+  data: {
+    reservation_ids: Array<string>
   }
 }

--- a/tests/resources/Bookable.spec.ts
+++ b/tests/resources/Bookable.spec.ts
@@ -102,3 +102,66 @@ test('deleteReservation()', async () => {
     },
   )
 })
+
+test('createOrder()', async () => {
+  const requestBody = {
+    booking_id: 'booking-uuid',
+  }
+  await bookable.createOrder(requestBody)
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith('/events/event-uuid/bookables/orders', {
+    method: 'post',
+    body: JSON.stringify(requestBody),
+  })
+})
+
+test('listOrders()', async () => {
+  await bookable.listOrders('booking-uuid')
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith(
+    '/events/event-uuid/bookables/orders?booking_id=booking-uuid',
+  )
+})
+
+test('getOrder()', async () => {
+  await bookable.getOrder('order-uuid')
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith(
+    '/events/event-uuid/bookables/orders/order-uuid',
+  )
+})
+
+test('addOrderLineItem()', async () => {
+  const requestBody = {
+    guest_code: 'ABC123',
+    addon_id: '68076f81-4598-8009-b047-82e482892527',
+    start_at: '2026-06-03',
+    end_at: '2026-06-06',
+    quantity: 1,
+  }
+  await bookable.addOrderLineItem('order-uuid', requestBody)
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith(
+    '/events/event-uuid/bookables/orders/order-uuid/line-items',
+    {
+      method: 'post',
+      body: JSON.stringify(requestBody),
+    },
+  )
+})
+
+test('deleteOrderLineItem()', async () => {
+  await bookable.deleteOrderLineItem('order-uuid', 'line-item-uuid')
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith(
+    '/events/event-uuid/bookables/orders/order-uuid/line-items/line-item-uuid',
+    {
+      method: 'delete',
+    },
+  )
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "./dist",
     "target": "ESNext",
     "module": "ESNext",
+    "moduleResolution": "node",
     "baseUrl": ".."
   },
   "include": [


### PR DESCRIPTION
## What

Adds SDK coverage for the new **bookables carrier order** endpoints on the public Event API. A carrier order is the permanent CART "hold" that add-on allocations (e.g. hotel nights) attach to.

New methods on the existing `Bookable` resource:

| Method | Endpoint | Returns |
|---|---|---|
| `createOrder({ booking_id })` | POST `/bookables/orders` | `{ data: Order }` |
| `listOrders(bookingId)` | GET `/bookables/orders?booking_id=` | `{ data: Order[] }` |
| `getOrder(orderUuid)` | GET `/bookables/orders/{order}` | `{ data: Order }` |
| `addOrderLineItem(orderUuid, body)` | POST `/bookables/orders/{order}/line-items` | `{ data: { reservation_ids } }` |
| `deleteOrderLineItem(orderUuid, lineItemUuid)` | DELETE `.../line-items/{lineItem}` | `void` |

Also: `OrderInterface` / `OrderLineItemInterface` (exported), README examples, tests, and a version bump to `0.0.24-beta1`.

## Why

The SDK is hand-written (no codegen), so the endpoints were added by hand. Orders are modelled as methods on `Bookable` — mirroring how reservations already live there — rather than a separate resource, keeping the established convention, naming, typing, and error handling.

`addOrderLineItem`'s `start_at` / `end_at` are optional since they're only required for non-FIXED add-ons.

## Build fix

The commit also fixes a pre-existing `yarn build` failure (present on `master`, unrelated to the feature): `tsconfig` set `module: ESNext` with no `moduleResolution`, so TS 5.9 fell back to the deprecated **`classic`** resolver and couldn't resolve transitive `@types` (`assertion-error` via `@types/chai`, an auto-included vitest dep). Fixed by setting `"moduleResolution": "node"`. Emit is unchanged (verified identical ESM output).

## Notes for reviewer

- The API's OpenAPI spec has **no formal `Order` schema** (responses are described in prose only), so `OrderInterface` is a pragmatic best-effort shape based on the endpoint descriptions ("a carrier order with its line items and add-on reservations"), matching the minimal style of the existing interfaces.

## Verification

- `yarn build` → clean
- `yarn test` → 51/51 passing (11 in `Bookable.spec.ts`, +5 new)
- `yarn lint` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)