### PR TITLE
feat(guests): add guest-import support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 dist
 .npmrc
 yarn-error.log
+openapi.yml

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airlst/sdk",
-  "version": "0.0.24-beta1",
+  "version": "0.0.24-beta2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/airlst/sdk-js.git"

--- a/src/Api.ts
+++ b/src/Api.ts
@@ -24,10 +24,10 @@ export const Api = class {
     }
   }
 
-  public static async sendRequest(
+  public static async sendRequest<T = ResponseInterface>(
     uri: string,
     options?: RequestInit,
-  ): Promise<ResponseInterface> {
+  ): Promise<T> {
     const response = await fetch(this.BASE_URL + uri, {
       headers: {
         ...Api.getRequestHeaders(),
@@ -44,7 +44,7 @@ export const Api = class {
       return await response.json()
     } catch {
       // If JSON parsing fails (empty body), just return
-      return {} as ResponseInterface
+      return {} as T
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,9 @@ import {
   GuestGroupInterface,
   OrderInterface,
   OrderLineItemInterface,
+  GuestsImportInterface,
+  ImportableFieldInterface,
+  GuessImportFieldsResponseInterface,
 } from './interfaces'
 
 export {
@@ -29,4 +32,7 @@ export {
   GuestGroupInterface,
   OrderInterface,
   OrderLineItemInterface,
+  GuestsImportInterface,
+  ImportableFieldInterface,
+  GuessImportFieldsResponseInterface,
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -160,3 +160,29 @@ export interface AvailabilityInterface {
   min: number
   max: number
 }
+
+export interface ImportableFieldInterface {
+  key: string
+  label: string
+}
+
+export interface GuestsImportInterface {
+  id: string
+  event_id: string
+  user_id: string | null
+  rows: number
+  status: 'created' | 'dispatched' | 'done'
+  batch_id: string | null
+  cloud_output_path: string | null
+  temporary_cloud_output_url: string | null
+  created_at: string
+}
+
+// Spec schema: GuessImportFieldsResponse
+export interface GuessImportFieldsResponseInterface {
+  available_fields: Array<ImportableFieldInterface>
+  possible_fields: Array<string | null>
+  header: Array<string>
+  preview_values: Array<Array<string>>
+  number_of_rows: number
+}

--- a/src/resources/Event.ts
+++ b/src/resources/Event.ts
@@ -18,7 +18,7 @@ export const Event = class {
     eventUuid: string,
     fileMimeType: string,
     isPrivate: boolean = true,
-  ): Promise<TemporaryUrlResponseInterface> {
+  ): Promise<SignedStorageUrlResponseInterface> {
     const { data } = await Api.sendRequest(
       `/events/${eventUuid}/signed-storage-url`,
       {
@@ -81,4 +81,13 @@ interface TemporaryUrlResponseInterface {
   uuid: string
   bucket: string
   key: string
+}
+
+// Returned by getSignedStorageUrl (PUT /events/{EventUuid}/signed-storage-url).
+// Superset of TemporaryUrlResponseInterface: adds the headers that must be sent
+// with the raw file PUT to the signed url. Widening the return type is
+// backward-compatible for existing consumers of generateTemporaryUploadUrl.
+export interface SignedStorageUrlResponseInterface
+  extends TemporaryUrlResponseInterface {
+  headers: Record<string, string | string[]>
 }

--- a/src/resources/Guest.ts
+++ b/src/resources/Guest.ts
@@ -4,7 +4,10 @@ import {
   BookingInterface,
   ContactInterface,
   AttachmentInterface,
+  GuestsImportInterface,
+  GuessImportFieldsResponseInterface,
 } from '../interfaces'
+import { Event } from './Event'
 import { QueryBuilder, QueryParameters } from '../utils/QueryBuilder'
 
 interface GuestListQueryParameters extends QueryParameters {
@@ -21,6 +24,28 @@ export const Guest = class {
   public static readonly CheckinType = {
     CHECK_IN: 'check-in',
     CHECK_OUT: 'check-out',
+  } as const
+
+  public static readonly ImportAction = {
+    CREATE: 'create',
+    UPDATE: 'update',
+  } as const
+
+  public static readonly ImportRole = {
+    AUTO: 'auto',
+    GUEST_MANAGER: 'guest_manager',
+  } as const
+
+  public static readonly MarketingOptInSetting = {
+    PRESENT: 'present',
+    NOT_PRESENT: 'not_present',
+    INDIVIDUAL: 'individual',
+  } as const
+
+  public static readonly ImportStatus = {
+    CREATED: 'created',
+    DISPATCHED: 'dispatched',
+    DONE: 'done',
   } as const
 
   public async list(
@@ -150,6 +175,70 @@ export const Guest = class {
       },
     )
   }
+
+  // Uploads the guest file privately and resolves to the S3 key to pass as the
+  // `file` field of guessImportFields / processImport. Fetches a signed storage
+  // url, PUTs the raw bytes with the returned headers (keeping the file private,
+  // read server-side with credentials), and never builds a public url.
+  public async uploadImportFile(
+    file: BodyInit,
+    fileMimeType: string,
+  ): Promise<string> {
+    const signed = await new Event().generateTemporaryUploadUrl(
+      this.eventId,
+      fileMimeType,
+      true,
+    )
+
+    const headers: Record<string, string> = {}
+    for (const [key, value] of Object.entries(signed.headers)) {
+      headers[key] = Array.isArray(value) ? value.join(',') : value
+    }
+
+    const response = await fetch(signed.url, {
+      method: 'put',
+      headers,
+      body: file,
+    })
+
+    if (!response.ok) {
+      throw response
+    }
+
+    return signed.key
+  }
+
+  public async guessImportFields(
+    body: GuessImportFieldsBodyInterface,
+  ): Promise<GuessImportFieldsResponseInterface> {
+    return await Api.sendRequest<GuessImportFieldsResponseInterface>(
+      `/events/${this.eventId}/guests/import/guess-fields`,
+      {
+        method: 'post',
+        body: JSON.stringify(body),
+      },
+    )
+  }
+
+  public async processImport(
+    body: ProcessGuestImportBodyInterface,
+  ): Promise<ProcessImportResponseInterface> {
+    return await Api.sendRequest<ProcessImportResponseInterface>(
+      `/events/${this.eventId}/guests/import`,
+      {
+        method: 'post',
+        body: JSON.stringify(body),
+      },
+    )
+  }
+
+  public async getImport(
+    guestsImportUuid: string,
+  ): Promise<ShowImportResponseInterface> {
+    return await Api.sendRequest<ShowImportResponseInterface>(
+      `/events/${this.eventId}/guests/import/${guestsImportUuid}`,
+    )
+  }
 }
 
 interface ListResponseInterface {
@@ -240,3 +329,41 @@ export interface CheckinBodyInterface {
 
 export interface CreateRecommendationBodyInterface
   extends CreateMainBodyInterface {}
+
+// Envelopes below mirror the spec exactly and are intentionally not normalized:
+// guessImportFields and processImport return top-level objects (no `data`
+// wrapper) while getImport nests under `data`.
+interface ProcessImportResponseInterface {
+  guestsImport: GuestsImportInterface
+}
+
+interface ShowImportResponseInterface {
+  data: {
+    guestsImport: GuestsImportInterface
+  }
+}
+
+export interface GuessImportFieldsBodyInterface {
+  file: string
+  first_row_as_header: boolean
+  role?: 'auto' | 'guest_manager'
+}
+
+export interface GuestImportDefaultsInterface {
+  'guest:status': string
+  'guest:guest_managers'?: Array<string>
+  'guest:guest_group_id'?: string
+  // Any other importable field key may be supplied as a default.
+  [key: string]: unknown
+}
+
+export interface ProcessGuestImportBodyInterface {
+  file: string
+  first_row_as_header: boolean
+  mapped_fields: Array<string | null>
+  action: 'create' | 'update'
+  role?: 'auto' | 'guest_manager'
+  defaults: GuestImportDefaultsInterface
+  required_fields?: Array<string>
+  marketing_opt_in_setting: 'present' | 'not_present' | 'individual'
+}

--- a/tests/resources/Event.spec.ts
+++ b/tests/resources/Event.spec.ts
@@ -30,6 +30,11 @@ test('generateTemporaryUploadUrl()', async () => {
       uuid: 'mock-uuid',
       key: 'mock-key',
       bucket: 'mock-bucket',
+      headers: {
+        Host: ['mock-storage-url.com'],
+        'x-amz-acl': ['private'],
+        'Content-Type': 'application/octet-stream',
+      },
     },
   }
   apiMock.mockResolvedValueOnce(signedUrlResponse)

--- a/tests/resources/Guest.spec.ts
+++ b/tests/resources/Guest.spec.ts
@@ -207,10 +207,13 @@ test('uploadImportFile()', async () => {
 
   // Signed storage url requested through Api (Event.generateTemporaryUploadUrl)
   expect(apiMock).toHaveBeenCalledTimes(1)
-  expect(apiMock).toHaveBeenCalledWith('/events/event-uuid/signed-storage-url', {
-    method: 'put',
-    body: JSON.stringify({ visibility: 'private', content_type: 'text/csv' }),
-  })
+  expect(apiMock).toHaveBeenCalledWith(
+    '/events/event-uuid/signed-storage-url',
+    {
+      method: 'put',
+      body: JSON.stringify({ visibility: 'private', content_type: 'text/csv' }),
+    },
+  )
 
   // Raw bytes PUT directly to the signed url with the flattened headers
   expect(fetch.requests().length).toEqual(1)
@@ -218,7 +221,9 @@ test('uploadImportFile()', async () => {
   expect(request.url).toEqual('https://mock-storage-url.com/upload')
   expect(request.method).toEqual('PUT')
   expect(request.headers.get('x-amz-acl')).toEqual('private')
-  expect(request.headers.get('content-type')).toEqual('application/octet-stream')
+  expect(request.headers.get('content-type')).toEqual(
+    'application/octet-stream',
+  )
 
   // Resolves to the private key to hand to guessImportFields / processImport
   expect(key).toEqual('mock-key')

--- a/tests/resources/Guest.spec.ts
+++ b/tests/resources/Guest.spec.ts
@@ -185,3 +185,85 @@ test('getAttachmentSignedUrl()', async () => {
     '/events/event-uuid/guests/guest-code/attachments/attachment-uuid/url',
   )
 })
+
+test('uploadImportFile()', async () => {
+  const signedUrlResponse = {
+    data: {
+      url: 'https://mock-storage-url.com/upload',
+      uuid: 'mock-uuid',
+      key: 'mock-key',
+      bucket: 'mock-bucket',
+      headers: {
+        Host: ['mock-storage-url.com'],
+        'x-amz-acl': ['private'],
+        'Content-Type': 'application/octet-stream',
+      },
+    },
+  }
+  apiMock.mockResolvedValueOnce(signedUrlResponse)
+  fetch.mockResponseOnce('')
+
+  const key = await guest.uploadImportFile('file-contents', 'text/csv')
+
+  // Signed storage url requested through Api (Event.generateTemporaryUploadUrl)
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith('/events/event-uuid/signed-storage-url', {
+    method: 'put',
+    body: JSON.stringify({ visibility: 'private', content_type: 'text/csv' }),
+  })
+
+  // Raw bytes PUT directly to the signed url with the flattened headers
+  expect(fetch.requests().length).toEqual(1)
+  const request = fetch.requests()[0]
+  expect(request.url).toEqual('https://mock-storage-url.com/upload')
+  expect(request.method).toEqual('PUT')
+  expect(request.headers.get('x-amz-acl')).toEqual('private')
+  expect(request.headers.get('content-type')).toEqual('application/octet-stream')
+
+  // Resolves to the private key to hand to guessImportFields / processImport
+  expect(key).toEqual('mock-key')
+})
+
+test('guessImportFields()', async () => {
+  const body = {
+    file: 'tmp/mock-key',
+    first_row_as_header: true,
+    role: Guest.ImportRole.AUTO,
+  }
+
+  guest.guessImportFields(body)
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith(
+    '/events/event-uuid/guests/import/guess-fields',
+    { method: 'post', body: JSON.stringify(body) },
+  )
+})
+
+test('processImport()', async () => {
+  const body = {
+    file: 'tmp/mock-key',
+    first_row_as_header: true,
+    mapped_fields: ['contact:first_name', null, 'contact:email'],
+    action: Guest.ImportAction.CREATE,
+    defaults: { 'guest:status': 'confirmed' },
+    marketing_opt_in_setting: Guest.MarketingOptInSetting.NOT_PRESENT,
+  }
+
+  guest.processImport(body)
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith('/events/event-uuid/guests/import', {
+    method: 'post',
+    body: JSON.stringify(body),
+  })
+})
+
+test('getImport()', async () => {
+  guest.getImport('import-uuid')
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith(
+    '/events/event-uuid/guests/import/import-uuid',
+  )
+})


### PR DESCRIPTION
## What

Adds SDK coverage for the AirLST guest importer API (**ACP-26988**), plus a high-level helper that encapsulates the recommended **private** upload flow so consumers don't hand-roll the signed-URL PUT dance.

### New `Guest` methods
- **`uploadImportFile(file, mimeType)`** — fetches a signed storage url, PUTs the raw file bytes to it with the returned headers (file stays **private**, read server-side with credentials — no public URL is built), and resolves to the S3 `key`. That key is what you pass as the `file` field below.
- **`guessImportFields(body)`** → `POST /guests/import/guess-fields` — preview + best-guess field mapping.
- **`processImport(body)`** → `POST /guests/import` — dispatch the import.
- **`getImport(uuid)`** → `GET /guests/import/{uuid}` — poll status (`dispatched → done`) and the error-report url.

Each is typed to the **exact** spec response envelope and intentionally **not normalized**: `guessImportFields`/`processImport` return top-level objects, `getImport` nests under `data`.

### Models (`interfaces.ts`, exported from `index`)
`GuestsImportInterface`, `ImportableFieldInterface`, `GuessImportFieldsResponseInterface`. Plus static enums on `Guest` (`ImportAction`, `ImportRole`, `MarketingOptInSetting`, `ImportStatus`) mirroring the existing `CheckinType` convention.

## Why
The SDK had no way to preview/upload/import guest files or poll import status, forcing consumers to hand-roll the private S3 upload against the raw API.

## Reviewer notes — nothing breaking
- **`Api.sendRequest` is now generic** (`<T = ResponseInterface>`). The default type parameter preserves every existing call and `const { data } = ...` destructure unchanged; it's only used to type the two import responses that have no `data` wrapper.
- **`Event.generateTemporaryUploadUrl` return type widened** to include `headers` via a new `SignedStorageUrlResponseInterface` (a superset of the existing shape). The method **signature, request body, and the `saveTemporaryUpload` parameter type are all unchanged** — I deliberately did *not* mutate `TemporaryUrlResponseInterface`, so no existing caller breaks.
- `file` still accepts a public URL string directly (backward compat); `uploadImportFile` is the recommended private path.
- The temporary `openapi.yml` spec is git-ignored, not committed.

## Testing
- `yarn build` — clean
- `yarn test` — **55 passing** (4 new Guest tests incl. the fetch-mocked upload flow; Event signed-url test extended with `headers`)
- `yarn lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)