### PR TITLE
feat(guest-groups): add quota-increase-request endpoints

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { QueryBuilder, QueryParameters } from './utils/QueryBuilder'
 import {
   GuestManagerInterface,
   GuestGroupInterface,
+  QuotaIncreaseRequestInterface,
   OrderInterface,
   OrderLineItemInterface,
   GuestsImportInterface,
@@ -30,6 +31,7 @@ export {
   QueryParameters,
   GuestManagerInterface,
   GuestGroupInterface,
+  QuotaIncreaseRequestInterface,
   OrderInterface,
   OrderLineItemInterface,
   GuestsImportInterface,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -43,6 +43,16 @@ export interface GuestManagerInterface
   managed_guests: Array<GuestInterface>
 }
 
+export interface QuotaIncreaseRequestInterface {
+  id: string
+  guest_group_id: string
+  requested_by_guest_manager_id: string
+  requested_amount: number
+  status: 'requested' | 'approved' | 'rejected'
+  created_at: string
+  resolved_at: string | null
+}
+
 export interface BookingInterface {
   extended_fields: object
 }

--- a/src/resources/GuestGroup.ts
+++ b/src/resources/GuestGroup.ts
@@ -1,5 +1,8 @@
 import { Api } from '../Api'
-import { GuestGroupInterface } from '../interfaces'
+import {
+  GuestGroupInterface,
+  QuotaIncreaseRequestInterface,
+} from '../interfaces'
 
 export const GuestGroup = class {
   public eventId: string
@@ -14,5 +17,64 @@ export const GuestGroup = class {
     )
 
     return data.guest_groups
+  }
+
+  public async listQuotaIncreaseRequests(
+    parameters: QuotaIncreaseRequestListParameters = {},
+  ): Promise<ListQuotaIncreaseRequestsResponseInterface> {
+    const query = new URLSearchParams()
+
+    if (parameters.guest_group_id) {
+      query.set('guest_group_id', parameters.guest_group_id)
+    }
+    if (parameters.guest_manager_id) {
+      query.set('guest_manager_id', parameters.guest_manager_id)
+    }
+    if (parameters.status) {
+      query.set('status', parameters.status)
+    }
+
+    const queryString = query.toString()
+
+    return await Api.sendRequest(
+      `/events/${this.eventId}/guest-groups/quota-increase-requests${
+        queryString ? `?${queryString}` : ''
+      }`,
+    )
+  }
+
+  public async createQuotaIncreaseRequest(
+    body: CreateQuotaIncreaseRequestBodyInterface,
+  ): Promise<CreateQuotaIncreaseRequestResponseInterface> {
+    return await Api.sendRequest(
+      `/events/${this.eventId}/guest-groups/quota-increase-requests`,
+      {
+        method: 'post',
+        body: JSON.stringify(body),
+      },
+    )
+  }
+}
+
+export interface QuotaIncreaseRequestListParameters {
+  guest_group_id?: string
+  guest_manager_id?: string
+  status?: 'requested' | 'approved' | 'rejected'
+}
+
+export interface CreateQuotaIncreaseRequestBodyInterface {
+  guest_manager_id: string
+  amount: number
+}
+
+interface ListQuotaIncreaseRequestsResponseInterface {
+  data: {
+    quota_increase_requests: Array<QuotaIncreaseRequestInterface>
+  }
+}
+
+interface CreateQuotaIncreaseRequestResponseInterface {
+  data: {
+    quota_increase_request: QuotaIncreaseRequestInterface
   }
 }

--- a/tests/resources/GuestGroup.spec.ts
+++ b/tests/resources/GuestGroup.spec.ts
@@ -22,3 +22,75 @@ test('list()', async () => {
   expect(apiMock).toHaveBeenCalledWith('/events/event-uuid/guest-groups')
   expect(result).toStrictEqual(guestGroups)
 })
+
+test('listQuotaIncreaseRequests() without filters', async () => {
+  const quotaIncreaseRequests = [
+    {
+      id: 'request-1',
+      guest_group_id: 'group-1',
+      requested_by_guest_manager_id: 'manager-1',
+      requested_amount: 5,
+      status: 'requested',
+      created_at: '2026-07-07T10:00:00.000000Z',
+      resolved_at: null,
+    },
+  ]
+  apiMock.mockResolvedValue({
+    data: { quota_increase_requests: quotaIncreaseRequests },
+  })
+
+  const result = await guestGroup.listQuotaIncreaseRequests()
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith(
+    '/events/event-uuid/guest-groups/quota-increase-requests',
+  )
+  expect(result).toStrictEqual({
+    data: { quota_increase_requests: quotaIncreaseRequests },
+  })
+})
+
+test('listQuotaIncreaseRequests() with filters', async () => {
+  guestGroup.listQuotaIncreaseRequests({
+    guest_group_id: 'group-1',
+    guest_manager_id: 'manager-1',
+    status: 'requested',
+  })
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith(
+    '/events/event-uuid/guest-groups/quota-increase-requests?guest_group_id=group-1&guest_manager_id=manager-1&status=requested',
+  )
+})
+
+test('createQuotaIncreaseRequest()', async () => {
+  const quotaIncreaseRequest = {
+    id: 'request-1',
+    guest_group_id: 'group-1',
+    requested_by_guest_manager_id: 'manager-1',
+    requested_amount: 5,
+    status: 'requested',
+    created_at: '2026-07-07T10:00:00.000000Z',
+    resolved_at: null,
+  }
+  apiMock.mockResolvedValue({
+    data: { quota_increase_request: quotaIncreaseRequest },
+  })
+
+  const result = await guestGroup.createQuotaIncreaseRequest({
+    guest_manager_id: 'manager-1',
+    amount: 5,
+  })
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith(
+    '/events/event-uuid/guest-groups/quota-increase-requests',
+    {
+      method: 'post',
+      body: JSON.stringify({ guest_manager_id: 'manager-1', amount: 5 }),
+    },
+  )
+  expect(result).toStrictEqual({
+    data: { quota_increase_request: quotaIncreaseRequest },
+  })
+})


### PR DESCRIPTION
## What

Adds SDK support for two new event-scoped, `X-Api-Key`-authenticated endpoints under `/api/events/{eventId}/guest-groups/quota-increase-requests` (spec operationIds `listGuestGroupQuotaIncreaseRequests` / `createGuestGroupQuotaIncreaseRequest`):

- **`GuestGroup.listQuotaIncreaseRequests(parameters?)`** — GET, with optional `guest_group_id`, `guest_manager_id`, and `status` (`requested | approved | rejected`) filters.
- **`GuestGroup.createQuotaIncreaseRequest(body)`** — POST `{ guest_manager_id, amount }`, where `amount` is a delta (>= 1) added to the group's current limit.

## Why

A guest manager can request an increase to the participation quota of the guest group they're bound to. Approval happens out-of-band via a signed email link in core — no approval endpoint is added here.

## Notes for reviewers

- Methods live on the existing `GuestGroup` resource class since the URLs sit under `/guest-groups/` and share its event-id-in-constructor scoping.
- Both methods return the raw `{ data: {...} }` envelope, matching the `Guest`/`GuestManager` convention and the literal spec response shape (rather than the unwrapped form `GuestGroup.list()` uses).
- List filters are plain optional query params built via `URLSearchParams` (only provided keys appended) — `QueryBuilder` is intentionally not used, since this endpoint has no pagination.
- 422 (unknown manager, manager without a bound group, unlimited group, invalid amount) surfaces as a thrown `Response` via `Api.sendRequest`, same as every other write endpoint — no endpoint-specific handling.
- Adds `QuotaIncreaseRequestInterface` (exported from the barrel) plus tests following existing `GuestGroup.spec.ts` conventions.

## Verification

- `yarn build` — clean
- `yarn test run tests/resources/GuestGroup.spec.ts` — 4/4 pass (3 new)
- `yarn run check` — prettier + eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)