### PR TITLE
feat(guests): add updateGuests bulk update method

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,25 @@ import { Guest } from '@airlst/sdk'
 const { data } = await new Guest('event-uuid').update('guest-code', { status: 'confirmed' })
 ```
 
+#### Update multiple guests
+
+```javascript
+import { Guest } from '@airlst/sdk'
+
+// Target specific guests by code
+await new Guest('event-uuid').updateGuests({
+  guests: ['ABCD1234', 'ABCD2345'],
+  status: 'confirmed',
+})
+
+// Or target every guest, optionally narrowed by filters
+await new Guest('event-uuid').updateGuests({
+  guests: 'all',
+  filters: { status: 'invited' },
+  status: 'confirmed',
+})
+```
+
 #### Archive guest
 
 ```javascript

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airlst/sdk",
-  "version": "0.0.24-beta3",
+  "version": "0.0.24-beta4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/airlst/sdk-js.git"

--- a/src/resources/Guest.ts
+++ b/src/resources/Guest.ts
@@ -129,6 +129,13 @@ export const Guest = class {
     })
   }
 
+  public async updateGuests(body: UpdateGuestsBodyInterface): Promise<void> {
+    await Api.sendRequest(`/events/${this.eventId}/guests`, {
+      method: 'put',
+      body: JSON.stringify(body),
+    })
+  }
+
   public async archive(code: string): Promise<void> {
     await Api.sendRequest(`/events/${this.eventId}/guests/${code}/archive`, {
       method: 'put',
@@ -318,6 +325,24 @@ export interface CreateCompanionBodyInterface {
 
 export interface UpdateBodyInterface {
   status: string
+}
+
+export interface UpdateGuestsBodyInterface {
+  guests: 'all' | Array<string>
+  filters?: {
+    status?: string
+    guest_group_id?: string
+  }
+  status?: string
+  guest_group_id?: string
+  max_companions?: number
+  max_recommendations?: number
+  marketing_opt_in?: boolean
+  guest_managers?: Array<string>
+  extended_fields?: object
+  booking?: BookingInterface
+  contact?: ContactInterface
+  send_automated_email?: boolean
 }
 
 export interface CheckinBodyInterface {

--- a/tests/resources/Guest.spec.ts
+++ b/tests/resources/Guest.spec.ts
@@ -108,6 +108,32 @@ test('update()', async () => {
   })
 })
 
+test('updateGuests()', async () => {
+  const body = { guests: ['ABCD1234', 'ABCD2345'], status: 'confirmed' }
+  guest.updateGuests(body)
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith('/events/event-uuid/guests', {
+    method: 'put',
+    body: JSON.stringify(body),
+  })
+})
+
+test('updateGuests() with "all" and filters', async () => {
+  const body = {
+    guests: 'all',
+    filters: { status: 'invited' },
+    status: 'confirmed',
+  }
+  guest.updateGuests(body)
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith('/events/event-uuid/guests', {
+    method: 'put',
+    body: JSON.stringify(body),
+  })
+})
+
 test('archive()', async () => {
   guest.archive('guest-code')
 


### PR DESCRIPTION
## What

Adds `Guest.updateGuests(body)` to the SDK for the AirLST public API bulk/mass guest-update endpoint — `PUT /api/events/{eventUuid}/guests` (operationId `updateGuests`). It applies one set of attribute changes to many guests at once and is processed **asynchronously** (`202 Accepted`, no body), so the method resolves to `void` — mirroring `archive()` / `delete()`.

## Why

The single-guest `update()` already exists, but there was no way to apply one change set to many guests in a single call. This fills that gap on the `Guest` resource.

## Changes

- **`src/resources/Guest.ts`**
  - New `updateGuests(body)` method (collection URL `PUT /events/{eventId}/guests`, `Promise<void>`), placed next to `update()`.
  - New exported `UpdateGuestsBodyInterface`: `guests: 'all' | string[]` (required), optional `filters` (`status`, `guest_group_id`, honored only when `guests` is `"all"`), plus the shared partial-update attribute set (`status`, `guest_group_id`, `max_companions`, `max_recommendations`, `marketing_opt_in`, `guest_managers`, `extended_fields`, `booking`, `contact`, `send_automated_email`). Reuses the existing `ContactInterface` / `BookingInterface`.
- **`tests/resources/Guest.spec.ts`** — two tests mirroring the `update()` test: `guests: [codes]`, and `guests: 'all'` + `filters`. Each asserts the exact request (`PUT /events/event-uuid/guests`, correct JSON body).
- **`README.md`** — new "Update multiple guests" section (both shapes; no `{ data }` destructure since the method returns void).
- **`package.json`** — version `0.0.24-beta3` → `0.0.24-beta4`.

## Usage

```javascript
import { Guest } from '@airlst/sdk'

// Target specific guests by code
await new Guest('event-uuid').updateGuests({
  guests: ['ABCD1234', 'ABCD2345'],
  status: 'confirmed',
})

// Or target every guest, optionally narrowed by filters
await new Guest('event-uuid').updateGuests({
  guests: 'all',
  filters: { status: 'invited' },
  status: 'confirmed',
})
```

## Verification

- `yarn build` (tsc) — clean
- `yarn vitest run` — 60 passed (`Guest.spec.ts` now 20 tests, +2)
- `yarn lint` — clean
- `yarn format` — all files unchanged (additions already conform)

## Reviewer notes

- The SDK is hand-written (no OpenAPI codegen), so the method was added by hand alongside `update()`.
- This branch was rebased onto the current `master` tip so the diff contains only these changes (the previous `version-bump` branch was already merged in #131).

🤖 Generated with [Claude Code](https://claude.com/claude-code)