### PR TITLE
feat(bookables): add bulk add-on assignment endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,3 +435,35 @@ import { Bookable } from '@airlst/sdk'
 
 await new Bookable('event-uuid').deleteOrderLineItem('order-uuid', 'line-item-uuid')
 ```
+
+#### Bulk-assign an add-on to many guests
+
+Assigns a single add-on selection to many guests at once. Processing is asynchronous, so the call resolves with no content once the batch has been queued.
+
+```javascript
+import { Bookable } from '@airlst/sdk'
+
+await new Bookable('event-uuid').assignBookables({
+  // Either an explicit list of guest codes, or the string 'all'
+  guests: ['ABCD1234', 'ABCD2345'],
+  // Optional: only applied when guests is 'all'
+  filters: {
+    status: 'confirmed',
+    guest_group_id: 'guest-group-uuid'
+  },
+  bookable_group_id: 'bookable-group-uuid',
+  // Must also include every flexible add-on referenced in selected_slots
+  selected_bookable_objects: ['bookable-object-uuid'],
+  // For FLEXIBLE add-ons: one reservation is created per slot
+  selected_slots: [
+    {
+      bookable_id: 'bookable-object-uuid',
+      start_at: '2026-06-03 09:00:00',
+      end_at: '2026-06-03 09:30:00'
+    }
+  ],
+  // Required when a NIGHTS add-on is selected (end_date = excluded check-out day)
+  start_date: '2026-06-03',
+  end_date: '2026-06-06'
+})
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airlst/sdk",
-  "version": "0.0.24-beta4",
+  "version": "0.0.24-beta5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/airlst/sdk-js.git"

--- a/src/resources/Bookable.ts
+++ b/src/resources/Bookable.ts
@@ -118,6 +118,13 @@ export const Bookable = class {
       },
     )
   }
+
+  public async assignBookables(body: AssignBookablesInterface): Promise<void> {
+    await Api.sendRequest(`/events/${this.eventId}/bookables/assignments`, {
+      method: 'post',
+      body: JSON.stringify(body),
+    })
+  }
 }
 
 interface ListGroupsResponseInterface {
@@ -193,4 +200,30 @@ interface AddOrderLineItemResponseInterface {
   data: {
     reservation_ids: Array<string>
   }
+}
+
+interface AssignBookablesInterface {
+  guests: 'all' | Array<string>
+  filters?: {
+    status?:
+      | 'listed'
+      | 'invited'
+      | 'requested'
+      | 'waitlisted'
+      | 'confirmed'
+      | 'cancelled'
+      | 'declined'
+      | 'unpaid'
+      | 'checkout'
+    guest_group_id?: string
+  }
+  bookable_group_id: string
+  selected_bookable_objects: Array<string>
+  selected_slots?: Array<{
+    bookable_id: string
+    start_at: string
+    end_at: string
+  }>
+  start_date?: string
+  end_date?: string
 }

--- a/tests/resources/Bookable.spec.ts
+++ b/tests/resources/Bookable.spec.ts
@@ -165,3 +165,74 @@ test('deleteOrderLineItem()', async () => {
     },
   )
 })
+
+test('assignBookables()', async () => {
+  const requestBody = {
+    guests: ['ABCD1234', 'ABCD2345'],
+    bookable_group_id: 'bookable-group-uuid',
+    selected_bookable_objects: ['bookable-object-uuid'],
+    selected_slots: [
+      {
+        bookable_id: 'bookable-object-uuid',
+        start_at: '2026-06-03 09:00:00',
+        end_at: '2026-06-03 09:30:00',
+      },
+    ],
+  }
+  await bookable.assignBookables(requestBody)
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith(
+    '/events/event-uuid/bookables/assignments',
+    {
+      method: 'post',
+      body: JSON.stringify(requestBody),
+    },
+  )
+})
+
+test('assignBookables() with guests: all and filters', async () => {
+  const requestBody = {
+    guests: 'all',
+    filters: {
+      status: 'confirmed',
+      guest_group_id: 'guest-group-uuid',
+    },
+    bookable_group_id: 'bookable-group-uuid',
+    selected_bookable_objects: ['bookable-object-uuid'],
+    start_date: '2026-06-03',
+    end_date: '2026-06-06',
+  }
+  await bookable.assignBookables(requestBody)
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith(
+    '/events/event-uuid/bookables/assignments',
+    {
+      method: 'post',
+      body: JSON.stringify(requestBody),
+    },
+  )
+})
+
+test('assignBookables() rejects on 422 validation error', async () => {
+  const response = new Response('{}', { status: 422 })
+  apiMock.mockRejectedValueOnce(response)
+
+  const requestBody = {
+    guests: [],
+    bookable_group_id: 'bookable-group-uuid',
+    selected_bookable_objects: ['bookable-object-uuid'],
+  }
+
+  await expect(bookable.assignBookables(requestBody)).rejects.toBe(response)
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith(
+    '/events/event-uuid/bookables/assignments',
+    {
+      method: 'post',
+      body: JSON.stringify(requestBody),
+    },
+  )
+})


### PR DESCRIPTION
## Summary

Adds SDK support for the new asynchronous public event-API endpoint **bulk add-on assignment** (`operationId: bulkAssignBookables`):

```
POST /api/events/{event}/bookables/assignments
```

It bulk-assigns a single add-on selection (hotel **nights** / **flexible** slots / **fixed** add-ons) to many event guests at once, targeting guests either by an explicit list of codes or by `"all"` (optionally narrowed by `filters`). The endpoint returns **202 Accepted with no body**, so the method resolves `void`.

## Changes

- **`src/resources/Bookable.ts`** — new `assignBookables(body)` method on the `Bookable` resource. Builds the POST body like `createOrder` and resolves `void` like the delete methods (empty 202 body is already handled by `Api.sendRequest`). Adds the local `AssignBookablesInterface` request type (unexported, mirroring `CreateOrderInterface`). No changes needed to `index.ts` / `interfaces.ts`.
- **`tests/resources/Bookable.spec.ts`** — 3 new tests mirroring the existing style: happy path (explicit guest codes + flexible slots), a `guests: "all"` + `filters` + nights-dates variant, and a 422 validation case.
- **`README.md`** — usage docs under the Bookables section.
- **`package.json`** — version bump `0.0.24-beta4` → `0.0.24-beta5`.

## Method signature

```ts
new Bookable('event-uuid').assignBookables({
  guests: ['ABCD1234', 'ABCD2345'], // or 'all'
  filters?: { status?, guest_group_id? }, // only honored when guests === 'all'
  bookable_group_id: 'uuid',
  selected_bookable_objects: ['uuid'], // must include every flexible add-on in selected_slots
  selected_slots?: [{ bookable_id, start_at, end_at }], // FLEXIBLE add-ons
  start_date?: 'yyyy-MM-dd', // required by API when a NIGHTS add-on is selected
  end_date?: 'yyyy-MM-dd'    // excluded check-out day
}): Promise<void>
```

## Verification

All run locally against the branch:

- `yarn build` (tsc) — ✅ passes
- `yarn lint` (eslint) — ✅ passes
- `yarn prettier --check src tests` — ✅ all files match Prettier style
- `yarn test run` (vitest) — ✅ 63 passed (8 files); `Bookable.spec.ts` now 14 tests (11 existing + 3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
