### PR TITLE
feat(secure-login): add issue/verify methods and id on the guest type (ACP-27056)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,11 @@ import { GuestManager } from './resources/GuestManager'
 import { GuestGroup } from './resources/GuestGroup'
 import { Contact } from './resources/Contact'
 import { Bookable } from './resources/Bookable'
+import {
+  SecureLogin,
+  IssueLoginCodeResponseInterface,
+  VerifyLoginCodeResponseInterface,
+} from './resources/SecureLogin'
 import { QueryBuilder, QueryParameters } from './utils/QueryBuilder'
 import {
   GuestManagerInterface,
@@ -27,6 +32,9 @@ export {
   EmailTemplate,
   Contact,
   Bookable,
+  SecureLogin,
+  IssueLoginCodeResponseInterface,
+  VerifyLoginCodeResponseInterface,
   QueryBuilder,
   QueryParameters,
   GuestManagerInterface,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -22,6 +22,7 @@ export interface GuestGroupInterface {
 }
 
 export interface GuestInterface {
+  id: string
   code: string
   role: string
   status: string

--- a/src/resources/SecureLogin.ts
+++ b/src/resources/SecureLogin.ts
@@ -1,0 +1,48 @@
+import { Api } from '../Api'
+
+export const SecureLogin = class {
+  public eventId: string
+
+  constructor(eventId: string) {
+    this.eventId = eventId
+  }
+
+  // Issues + emails a one-time login code for the guest resolved from `code`.
+  // The destination address is resolved server-side; nothing sensitive is
+  // returned. `nonce` (optional) binds the code to the caller's session for
+  // cross-session replay protection.
+  public async issue(
+    code: string,
+    nonce?: string,
+  ): Promise<IssueLoginCodeResponseInterface> {
+    return await Api.sendRequest(`/events/${this.eventId}/secure-login/issue`, {
+      method: 'post',
+      body: JSON.stringify({ code, nonce }),
+    })
+  }
+
+  // Verifies an emitted code. Enforces attempt cap, expiry and single-use
+  // server-side; must pass the same `nonce` given to `issue` when one was used.
+  public async verify(
+    code: string,
+    otp: string,
+    nonce?: string,
+  ): Promise<VerifyLoginCodeResponseInterface> {
+    return await Api.sendRequest(`/events/${this.eventId}/secure-login/verify`, {
+      method: 'post',
+      body: JSON.stringify({ code, otp, nonce }),
+    })
+  }
+}
+
+// Both endpoints return a top-level object (no `data` envelope), mirroring the
+// Suite's secure-login contract.
+export interface IssueLoginCodeResponseInterface {
+  sent: boolean
+  reason?: 'cooldown'
+}
+
+export interface VerifyLoginCodeResponseInterface {
+  ok: boolean
+  reason?: 'expired' | 'too_many_attempts' | 'invalid'
+}

--- a/src/resources/SecureLogin.ts
+++ b/src/resources/SecureLogin.ts
@@ -28,10 +28,13 @@ export const SecureLogin = class {
     otp: string,
     nonce?: string,
   ): Promise<VerifyLoginCodeResponseInterface> {
-    return await Api.sendRequest(`/events/${this.eventId}/secure-login/verify`, {
-      method: 'post',
-      body: JSON.stringify({ code, otp, nonce }),
-    })
+    return await Api.sendRequest(
+      `/events/${this.eventId}/secure-login/verify`,
+      {
+        method: 'post',
+        body: JSON.stringify({ code, otp, nonce }),
+      },
+    )
   }
 }
 

--- a/src/resources/SecureLogin.ts
+++ b/src/resources/SecureLogin.ts
@@ -11,6 +11,11 @@ export const SecureLogin = class {
   // The destination address is resolved server-side; nothing sensitive is
   // returned. `nonce` (optional) binds the code to the caller's session for
   // cross-session replay protection.
+  //
+  // Note: an unknown code or a guest with no email on file comes back as a
+  // thrown HTTP error (404 / 422), not an in-band `{ sent: false }` — the
+  // `{ sent: false }` shape is only used for the `cooldown` case, so callers
+  // should catch rejections.
   public async issue(
     code: string,
     nonce?: string,

--- a/tests/resources/SecureLogin.spec.ts
+++ b/tests/resources/SecureLogin.spec.ts
@@ -1,0 +1,53 @@
+import { afterEach, test, expect, vi } from 'vitest'
+import { Api, SecureLogin } from '../../src'
+
+const apiMock = (Api.sendRequest = vi.fn())
+
+const secureLogin = new SecureLogin('event-uuid')
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+test('issue()', async () => {
+  secureLogin.issue('guest-code')
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith(
+    '/events/event-uuid/secure-login/issue',
+    { method: 'post', body: '{"code":"guest-code"}' },
+  )
+})
+
+test('issue() with nonce', async () => {
+  secureLogin.issue('guest-code', 'session-abc')
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith(
+    '/events/event-uuid/secure-login/issue',
+    { method: 'post', body: '{"code":"guest-code","nonce":"session-abc"}' },
+  )
+})
+
+test('verify()', async () => {
+  secureLogin.verify('guest-code', '123456')
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith(
+    '/events/event-uuid/secure-login/verify',
+    { method: 'post', body: '{"code":"guest-code","otp":"123456"}' },
+  )
+})
+
+test('verify() with nonce', async () => {
+  secureLogin.verify('guest-code', '123456', 'session-abc')
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith(
+    '/events/event-uuid/secure-login/verify',
+    {
+      method: 'post',
+      body: '{"code":"guest-code","otp":"123456","nonce":"session-abc"}',
+    },
+  )
+})

--- a/tests/resources/SecureLogin.spec.ts
+++ b/tests/resources/SecureLogin.spec.ts
@@ -10,7 +10,7 @@ afterEach(() => {
 })
 
 test('issue()', async () => {
-  secureLogin.issue('guest-code')
+  await secureLogin.issue('guest-code')
 
   expect(apiMock).toHaveBeenCalledTimes(1)
   expect(apiMock).toHaveBeenCalledWith(
@@ -20,7 +20,7 @@ test('issue()', async () => {
 })
 
 test('issue() with nonce', async () => {
-  secureLogin.issue('guest-code', 'session-abc')
+  await secureLogin.issue('guest-code', 'session-abc')
 
   expect(apiMock).toHaveBeenCalledTimes(1)
   expect(apiMock).toHaveBeenCalledWith(
@@ -30,7 +30,7 @@ test('issue() with nonce', async () => {
 })
 
 test('verify()', async () => {
-  secureLogin.verify('guest-code', '123456')
+  await secureLogin.verify('guest-code', '123456')
 
   expect(apiMock).toHaveBeenCalledTimes(1)
   expect(apiMock).toHaveBeenCalledWith(
@@ -40,7 +40,7 @@ test('verify()', async () => {
 })
 
 test('verify() with nonce', async () => {
-  secureLogin.verify('guest-code', '123456', 'session-abc')
+  await secureLogin.verify('guest-code', '123456', 'session-abc')
 
   expect(apiMock).toHaveBeenCalledTimes(1)
   expect(apiMock).toHaveBeenCalledWith(


### PR DESCRIPTION
## What & why
SDK half of **Secure Login for exhibitors** ([ACP-27056](https://app.clickup.com/t/86caj5mf6)). Exposes the Suite's new email-OTP endpoints (see airlst/core#5463) so the exhibitor BFF can drop its in-memory mock, and fixes the missing `id` on the guest type.

## Changes
- **`SecureLogin` resource** (`src/resources/SecureLogin.ts`):
  - `new SecureLogin(eventId).issue(code, nonce?)` → `{ sent, reason?: 'cooldown' }`
  - `new SecureLogin(eventId).verify(code, otp, nonce?)` → `{ ok, reason?: 'expired' | 'too_many_attempts' | 'invalid' }`
  - `nonce` is optional (session-replay binding); omitted from the body when unset.
- **`id: string` on `GuestInterface`** — present at runtime but previously untyped; needed to address guests by their non-secret id (managed-guest scope check). `ContactInterface` already carries `full_name`/`email`, so no change there.
- Exported `SecureLogin` + its response interfaces from `index.ts`.
- 4 unit tests (URI + method + body, with/without nonce).

## Verify
`yarn build` ✓ · `yarn lint` ✓ · `yarn test` → 67 passed (9 files).

## Notes
- Version bump intentionally omitted (handled by a separate release PR, per repo convention).
- The BFF then wires these into `server/utils/suiteAuth/real.js` (its issue 13) and flips `NUXT_SECURE_LOGIN_MOCK=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)