### PR TITLE
feat(bookables): surface per_night_price on availability response (ACP-27725)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airlst/sdk",
-  "version": "0.0.24-beta6",
+  "version": "0.0.24-beta7",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/airlst/sdk-js.git"

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -164,9 +164,19 @@ export interface OrderLineItemInterface {
   quantity: number
 }
 
+export interface PriceInterface {
+  net: number
+  gross: number
+  vat: number
+  vat_rate: number
+}
+
 export interface AvailabilityInterface {
   starts_at: string
   ends_at: string
+  per_night_total_capacity: Record<string, Record<string, number>> | null
+  per_night_remaining_capacity: Record<string, Record<string, number>> | null
+  per_night_price: Record<string, Record<string, PriceInterface>> | null
   buffer_time: number
   min: number
   max: number


### PR DESCRIPTION
## Summary

Surface the new `per_night_price` field on the bookable availability endpoint (`getAvailabilities` / `Bookable.listAvailabilities()`) — **ACP-27725**.

Backend: airlst/core#5516

## Changes

- `AvailabilityInterface` now exposes the per-night trio, all typed as `Record<guestGroupId, Record<dateString, T>> | null`:
  - `per_night_total_capacity` / `per_night_remaining_capacity` → `number`
  - `per_night_price` → new `PriceInterface`
- New `PriceInterface`: `{ net, gross, vat, vat_rate }` (minor units/cents; `gross` VAT-inclusive; `vat_rate` whole-number percent).
- Version bump `0.0.24-beta6` → `0.0.24-beta7`.

`null` for non-NIGHTS bookables (tickets, flexible/fixed add-ons); populated for NIGHTS hotels. Null-group rows use the null UUID `00000000-0000-0000-0000-000000000000`. **Additive, non-breaking.**

> Note: `per_night_total_capacity` / `per_night_remaining_capacity` were not previously present in the SDK's `AvailabilityInterface` either, so the whole trio is added here — not just `per_night_price`.

`PriceInterface` is exported from `interfaces.ts` but, like `AvailabilityInterface`, is not re-exported from `index.ts` (reachable structurally via the method return type). Can surface both as named public exports if desired.

## Verification

- `yarn build` (tsc) — clean
- `yarn test` — **67/67 pass** (availability tests assert request shape only, unaffected)
- `yarn lint` — clean
- Strict `tsc --noEmit` type-proof: field access (`per_night_price?.[groupId]?.[date]?.vat_rate`), null branch, and `PriceInterface` shape all valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
