### PR TITLE
feat(guests): accept contact_id on guest creation (ACP-27003)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,33 @@ const { data } = await new Guest('event-uuid').create({
 })
 ```
 
+#### Create a guest linked to an existing contact
+
+Pass `contact_id` instead of `contact` to attach the guest to a contact that
+already exists, rather than creating a new one. The contact must belong to the
+event's company.
+
+`contact_id` and `contact` are mutually exclusive — sending both fails
+validation. To correct the contact's data as well, create the guest and then
+call `update()` with the `contact` fields.
+
+```javascript
+import { Guest } from '@airlst/sdk'
+
+const { data } = await new Guest('event-uuid').create({
+  status: 'confirmed',
+  contact_id: 'contact-uuid',
+  companions: [
+    { contact_id: 'another-contact-uuid' },
+    { contact: { first_name: 'Jane', last_name: 'Doe' } },
+  ]
+})
+```
+
+`GuestManager.create()` accepts `contact_id` as well. It is **not** accepted by
+`createCompanion()` or `createRecommendation()` — those endpoints do not
+support it.
+
 #### Create a new companion guest
 
 ```javascript

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airlst/sdk",
-  "version": "0.0.24-beta7",
+  "version": "0.0.24-beta8",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/airlst/sdk-js.git"

--- a/src/resources/Guest.ts
+++ b/src/resources/Guest.ts
@@ -313,14 +313,31 @@ interface UpdateResponseInterface {
 
 export interface CreateMainBodyInterface extends CreateCompanionBodyInterface {
   status: string
+  // Links the guest to an existing contact of the event's company instead of
+  // creating a new one. Mutually exclusive with `contact` — sending both is a
+  // 422. To also correct the contact data, follow up with update().
+  // Accepted only by POST /events/{event}/guests, so it is subtracted from
+  // CreateRecommendationBodyInterface below. GuestManager.create() posts to
+  // that same endpoint, so it accepts contact_id too.
+  contact_id?: string
+  companions?: Array<CreateNestedCompanionBodyInterface>
 }
 
 export interface CreateCompanionBodyInterface {
-  code: string
-  role: string
-  extended_fields: object
-  contact: ContactInterface
-  booking: BookingInterface
+  code?: string
+  role?: string
+  extended_fields?: object
+  contact?: ContactInterface
+  booking?: BookingInterface
+}
+
+// A companion sent inline in the create() payload. Unlike createCompanion(),
+// this path accepts contact_id (companions.*.contact_id on the API).
+export interface CreateNestedCompanionBodyInterface
+  extends CreateCompanionBodyInterface {
+  status?: string
+  send_automated_email?: boolean
+  contact_id?: string
 }
 
 export interface UpdateBodyInterface {
@@ -352,8 +369,10 @@ export interface CheckinBodyInterface {
   timestamp: number
 }
 
+// POST /guests/{code}/recommendations accepts neither contact_id nor inline
+// companions, so both are subtracted from the inherited create body.
 export interface CreateRecommendationBodyInterface
-  extends CreateMainBodyInterface {}
+  extends Omit<CreateMainBodyInterface, 'contact_id' | 'companions'> {}
 
 // Envelopes below mirror the spec exactly and are intentionally not normalized:
 // guessImportFields and processImport return top-level objects (no `data`

--- a/src/resources/GuestManager.ts
+++ b/src/resources/GuestManager.ts
@@ -8,6 +8,12 @@ import {
   GetSignerUrlResponseInterface,
 } from './Guest'
 
+// Guest managers are created through POST /events/{event}/guests with the role
+// forced, so contact_id applies — but the API prohibits companions for that
+// role, so the inline companions field is subtracted.
+export interface CreateGuestManagerBodyInterface
+  extends Omit<CreateMainBodyInterface, 'companions'> {}
+
 export const GuestManager = class {
   public eventId: string
 
@@ -64,7 +70,7 @@ export const GuestManager = class {
   }
 
   public async create(
-    body: CreateMainBodyInterface,
+    body: CreateGuestManagerBodyInterface,
   ): Promise<CreateResponseInterface> {
     return await Api.sendRequest(`/events/${this.eventId}/guests`, {
       method: 'post',

--- a/tests/resources/Guest.spec.ts
+++ b/tests/resources/Guest.spec.ts
@@ -85,6 +85,33 @@ test('create()', async () => {
   })
 })
 
+test('create() with contact_id', async () => {
+  guest.create({ status: 'confirmed', contact_id: 'contact-uuid' })
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith('/events/event-uuid/guests', {
+    method: 'post',
+    body: '{"status":"confirmed","contact_id":"contact-uuid"}',
+  })
+})
+
+test('create() with contact_id on nested companions', async () => {
+  guest.create({
+    status: 'confirmed',
+    contact_id: 'contact-uuid',
+    companions: [
+      { contact_id: 'companion-contact-uuid' },
+      { contact: { first_name: 'Jane' } },
+    ],
+  })
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith('/events/event-uuid/guests', {
+    method: 'post',
+    body: '{"status":"confirmed","contact_id":"contact-uuid","companions":[{"contact_id":"companion-contact-uuid"},{"contact":{"first_name":"Jane"}}]}',
+  })
+})
+
 test('createCompanion()', async () => {
   guest.createCompanion('guest-code', { a: 'b' })
 

--- a/tests/resources/GuestManager.spec.ts
+++ b/tests/resources/GuestManager.spec.ts
@@ -60,6 +60,16 @@ test('create()', async () => {
   })
 })
 
+test('create() with contact_id', async () => {
+  guestManager.create({ status: 'confirmed', contact_id: 'contact-uuid' })
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith('/events/event-uuid/guests', {
+    method: 'post',
+    body: '{"status":"confirmed","contact_id":"contact-uuid","role":"guest_manager"}',
+  })
+})
+
 test('update()', async () => {
   guestManager.update('guest-code', { a: 'b' })
 


### PR DESCRIPTION
Mirrors core [airlst/core#5537](https://github.com/airlst/core/pull/5537) (ACP-27003). Needed for the Sonepar Ausstellershop 2027 build, where one contact registers for several fair events and every registration must link to the same contact.

## Endpoint scope

`contact_id` is optional, a uuid, and mutually exclusive with `contact` — sending both is a 422. The contact must belong to the event's company.

| Method | Endpoint | Accepts `contact_id` |
|---|---|---|
| `Guest.create()` | `POST /events/{event}/guests` | ✅ main body |
| `Guest.create()` | …`companions[]` | ✅ per companion |
| `GuestManager.create()` | same endpoint, `role` forced | ✅ |
| `Guest.createCompanion()` | `POST /guests/{code}/companions` | ❌ |
| `Guest.createRecommendation()` | `POST /guests/{code}/recommendations` | ❌ |

Verified against core, not just the spec: `grep -rn contact_id app/Domain/*/Http/Requests/` hits only `StoreGuestsRequest`, and the property was added inline to the operation rather than to the shared `ContactPayload` schema.

## Type changes

`contact_id` is declared on `CreateMainBodyInterface` and subtracted from `CreateRecommendationBodyInterface`, which extends it — otherwise the inheritance chain would advertise it on an endpoint that ignores it.

Two supporting changes were needed to make the field usable at all:

1. **Inline companions had no representation in the SDK.** There was no `companions` field anywhere, so companion-level `contact_id` was unreachable. Added `companions?: Array<CreateNestedCompanionBodyInterface>`, carrying `contact_id`, `status` and `send_automated_email`. `GuestManager.create()` takes a new `CreateGuestManagerBodyInterface` that omits `companions`, which the API prohibits for that role.
2. **`code`, `role`, `extended_fields`, `contact` and `booking` were declared required** even though the API treats them as nullable, so a `contact_id`-only payload did not typecheck. Widened to optional — non-breaking for callers, and it fixes the README's own companion example, which did not compile against the old type.

Deliberately not modelling the mutual exclusivity as a discriminated union: it would mean converting the exported `interface`s to `type`s and breaking any downstream `extends`. Server-side validation is the real guard; the constraint is documented in a comment and in the README.

## Verification

`yarn run check` (prettier + eslint), `yarn run test` (70 passed), `yarn run build` all clean.

The `Omit` cannot be covered by the test suite — `tsconfig.json` includes only `src/**/*` and vitest does not typecheck. Verified instead with a throwaway `tsc --noEmit` pass that exited 0 with `@ts-expect-error` on the negative cases, which proves both directions: `contact_id` compiles on `create()` and on nested companions, and is genuinely rejected on `createRecommendation()` and `createCompanion()`.

## Release

Version bumped `0.0.24-beta7` → `0.0.24-beta8`. `origin/master`, the latest GitHub release and `npm dist-tags` all agreed on beta7, and it is a pre-release, so the beta counter increments.

**Do not merge before core#5537 is deployed** to the environment consumers hit — the SDK would otherwise advertise a field the live API does not validate, which silently duplicates contacts rather than erroring. After merge, the release must be cut with `--prerelease`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)