### PR TITLE
feat(contact): add Contact.update() for pre-registration Stammdaten (ACP-27933)

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,26 @@ import { Contact } from '@airlst/sdk'
 const { data } = await new Contact().getEvents('contact-code')
 ```
 
+#### Update contact master data
+
+Updates a contact's master data by code — native fields and `extended_fields` —
+without creating a guest or registration. All fields are optional: native
+fields are overwritten when present, and `extended_fields` are merged key by
+key (existing keys are preserved). Returns the updated contact, same shape as
+`get()`.
+
+```javascript
+import { Contact } from '@airlst/sdk'
+
+const { data } = await new Contact().update('contact-code', {
+  contact: {
+    first_name: 'Jane',
+    mobile: '+4915212345678',
+    extended_fields: { stammdaten_saved: true },
+  },
+})
+```
+
 #### Get all guest attachments
 
 ```javascript

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airlst/sdk",
-  "version": "0.0.24-beta8",
+  "version": "0.0.24-beta9",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/airlst/sdk-js.git"

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -66,6 +66,7 @@ export interface ContactInterface {
   last_name: string
   email: string
   phone: string
+  mobile: string
   company_name: string
   job_title: string
   address_line_1: string

--- a/src/resources/Contact.ts
+++ b/src/resources/Contact.ts
@@ -18,6 +18,16 @@ export const Contact = class {
   public async getEvents(code: string): Promise<GetEventsResponseInterface> {
     return await Api.sendRequest(`/companies/contacts/${code}/events`)
   }
+
+  public async update(
+    code: string,
+    body: UpdateBodyInterface,
+  ): Promise<UpdateResponseInterface> {
+    return await Api.sendRequest(`/companies/contacts/${code}`, {
+      method: 'put',
+      body: JSON.stringify(body),
+    })
+  }
 }
 
 interface ValidateCodeResponseInterface {
@@ -35,5 +45,38 @@ interface GetResponseInterface {
 interface GetEventsResponseInterface {
   data: {
     events: Array<EventInterface>
+  }
+}
+
+export interface UpdateBodyInterface {
+  contact: UpdateContactInterface
+}
+
+// Writable contact fields for PUT /companies/contacts/{code}. Every field is
+// optional: the endpoint does a partial merge, overwriting native fields that
+// are present and merging extended_fields key by key. Distinct from the
+// response ContactInterface, which also carries read-only fields (code,
+// full_name) that this endpoint does not accept.
+export interface UpdateContactInterface {
+  sex?: string
+  title?: string
+  first_name?: string
+  last_name?: string
+  email?: string
+  phone?: string
+  mobile?: string
+  company_name?: string
+  job_title?: string
+  address_line_1?: string
+  address_line_2?: string
+  zip?: string
+  city?: string
+  country?: string
+  extended_fields?: object
+}
+
+interface UpdateResponseInterface {
+  data: {
+    contact: ContactInterface
   }
 }

--- a/tests/resources/Contact.spec.ts
+++ b/tests/resources/Contact.spec.ts
@@ -34,3 +34,19 @@ test('getEvents()', async () => {
     '/companies/contacts/contact-code/events',
   )
 })
+
+test('update()', async () => {
+  contact.update('contact-code', {
+    contact: {
+      first_name: 'Jane',
+      mobile: '+4915212345678',
+      extended_fields: { stammdaten_saved: true },
+    },
+  })
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith('/companies/contacts/contact-code', {
+    method: 'put',
+    body: '{"contact":{"first_name":"Jane","mobile":"+4915212345678","extended_fields":{"stammdaten_saved":true}}}',
+  })
+})


### PR DESCRIPTION
## Why

Syncs `@airlst/sdk` to the core API change in [airlst/core#5538](https://github.com/airlst/core/pull/5538) (ACP-27933). Core added a contact-write endpoint so exhibitors can save master data (**Stammdaten**) *before* any event registration exists — previously the only write path for contact data was nested in a guest create/update, which creates a registration.

## What

### `Contact.update(code, body)` — new
Mirrors `PUT /api/companies/contacts/{ContactCode}` (operationId `updateContact`). Company-API-key auth; updates a contact's native fields + `extended_fields` by code with **no guest/booking side-effect**, returning the contact in the same shape as `get()`.

- Body is nested `{ contact: { … } }` (matches the endpoint's request shape).
- `UpdateContactInterface` holds the **writable** native fields + `extended_fields`, all **optional** — the endpoint does a partial merge (native fields overwritten when present, `extended_fields` merged key-by-key), so partial Stammdaten saves typecheck. Kept distinct from the response `ContactInterface`, which also carries read-only `code`/`full_name` the endpoint does not accept.

### `mobile` added to `ContactInterface`
Core added `mobile` to the shared `ContactPayload`. The `getContactDetails` response already returns `mobile`, and the guest-write contact object accepts it, so it belongs on the shared interface (used as both the response type and the nested write body in guest creation/update).

## Endpoint scope

- **Accepts these fields:** `PUT /api/companies/contacts/{ContactCode}` (all writable fields above). `mobile` is additionally accepted by the guest-write contact object (`POST/PUT .../guests…`), which is why it lives on the shared `ContactInterface`.
- **No SDK surface:** core also widened `createExtendedField`'s `model` enum to accept `contact`/`event`, but the SDK does not expose extended-field authoring (no `ExtendedField` resource), so there is nothing to mirror for that part.
- **Pre-existing response gaps (left out of scope):** the SDK's `ContactInterface` still omits `title` and `locale_id`, which the core response returns. Not introduced by this change; can be addressed separately.

## Version

`0.0.24-beta8` → `0.0.24-beta9` (beta counter increment per the update-sdk-js skill).

## Tests

`yarn run check`, `yarn run test --run` (71 pass, incl. the new `Contact.update()` case), and `yarn run build` all green; `dist/*.d.ts` confirms the optional writable body and `mobile`.

## ⚠️ Do not merge before core is deployed

Per the skill: the SDK must not advertise a field the live API doesn't validate yet. Hold this until [airlst/core#5538](https://github.com/airlst/core/pull/5538) is merged and deployed to the environment consumers hit. Release (npm publish via a GitHub release) is intentionally **not** part of this PR — cut it after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
