### PR TITLE
feat(guests): accept contact_code and expose contact id (ACP-27003)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,20 +114,24 @@ const { data } = await new Guest('event-uuid').create({
 
 #### Create a guest linked to an existing contact
 
-Pass `contact_id` instead of `contact` to attach the guest to a contact that
-already exists, rather than creating a new one. The contact must belong to the
-event's company.
+Pass `contact_id` **or** `contact_code` instead of `contact` to attach the guest
+to a contact that already exists, rather than creating a new one. The contact
+must belong to the event's company.
 
-`contact_id` and `contact` are mutually exclusive — sending both fails
-validation. To correct the contact's data as well, create the guest and then
-call `update()` with the `contact` fields.
+Use `contact_code` when you authenticated the contact by code and never resolved
+its id — it is the same code `Contact.get()` takes and returns. Otherwise use
+`contact_id`, which `Contact.get()` also returns as `data.contact.id`.
+
+`contact`, `contact_id` and `contact_code` are mutually exclusive — sending any
+pair fails validation. To correct the contact's data as well, create the guest
+and then call `update()` with the `contact` fields.
 
 ```javascript
 import { Guest } from '@airlst/sdk'
 
 const { data } = await new Guest('event-uuid').create({
   status: 'confirmed',
-  contact_id: 'contact-uuid',
+  contact_code: 'QOI1U9GX',
   companions: [
     { contact_id: 'another-contact-uuid' },
     { contact: { first_name: 'Jane', last_name: 'Doe' } },
@@ -135,9 +139,9 @@ const { data } = await new Guest('event-uuid').create({
 })
 ```
 
-`GuestManager.create()` accepts `contact_id` as well. It is **not** accepted by
+`GuestManager.create()` accepts both as well. Neither is accepted by
 `createCompanion()` or `createRecommendation()` — those endpoints do not
-support it.
+support them.
 
 #### Create a new companion guest
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airlst/sdk",
-  "version": "0.0.24-beta9",
+  "version": "0.0.24-beta10",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/airlst/sdk-js.git"

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -58,23 +58,29 @@ export interface BookingInterface {
   extended_fields: object
 }
 
+// Used both as a response shape and as a request body (guest create/update,
+// Contact.update), so every field is optional: the API treats them as nullable
+// and callers routinely send a partial object.
 export interface ContactInterface {
-  code: string
-  sex: string
-  full_name: string
-  first_name: string
-  last_name: string
-  email: string
-  phone: string
-  mobile: string
-  company_name: string
-  job_title: string
-  address_line_1: string
-  address_line_2: string
-  zip: string
-  city: string
-  country: string
-  extended_fields: object
+  // Response only. Pass it back as `contact_id` on guest creation to link the
+  // new guest to this contact instead of creating a duplicate.
+  id?: string
+  code?: string
+  sex?: string
+  full_name?: string
+  first_name?: string
+  last_name?: string
+  email?: string
+  phone?: string
+  mobile?: string
+  company_name?: string
+  job_title?: string
+  address_line_1?: string
+  address_line_2?: string
+  zip?: string
+  city?: string
+  country?: string
+  extended_fields?: object
 }
 
 export interface EmailTemplateInterface {

--- a/src/resources/Guest.ts
+++ b/src/resources/Guest.ts
@@ -314,12 +314,15 @@ interface UpdateResponseInterface {
 export interface CreateMainBodyInterface extends CreateCompanionBodyInterface {
   status: string
   // Links the guest to an existing contact of the event's company instead of
-  // creating a new one. Mutually exclusive with `contact` — sending both is a
-  // 422. To also correct the contact data, follow up with update().
-  // Accepted only by POST /events/{event}/guests, so it is subtracted from
-  // CreateRecommendationBodyInterface below. GuestManager.create() posts to
-  // that same endpoint, so it accepts contact_id too.
+  // creating a new one. Mutually exclusive with `contact` and with each other —
+  // sending any pair is a 422. To also correct the contact data, follow up with
+  // update(). Accepted only by POST /events/{event}/guests, so both are
+  // subtracted from CreateRecommendationBodyInterface below.
+  // GuestManager.create() posts to that same endpoint, so it accepts them too.
   contact_id?: string
+  // The contact code, as returned by Contact.get(). Use this when you
+  // authenticated the contact by code and never resolved its id.
+  contact_code?: string
   companions?: Array<CreateNestedCompanionBodyInterface>
 }
 
@@ -338,6 +341,7 @@ export interface CreateNestedCompanionBodyInterface
   status?: string
   send_automated_email?: boolean
   contact_id?: string
+  contact_code?: string
 }
 
 export interface UpdateBodyInterface {
@@ -369,10 +373,13 @@ export interface CheckinBodyInterface {
   timestamp: number
 }
 
-// POST /guests/{code}/recommendations accepts neither contact_id nor inline
-// companions, so both are subtracted from the inherited create body.
+// POST /guests/{code}/recommendations accepts neither contact linking nor inline
+// companions, so all three are subtracted from the inherited create body.
 export interface CreateRecommendationBodyInterface
-  extends Omit<CreateMainBodyInterface, 'contact_id' | 'companions'> {}
+  extends Omit<
+    CreateMainBodyInterface,
+    'contact_id' | 'contact_code' | 'companions'
+  > {}
 
 // Envelopes below mirror the spec exactly and are intentionally not normalized:
 // guessImportFields and processImport return top-level objects (no `data`

--- a/tests/resources/Guest.spec.ts
+++ b/tests/resources/Guest.spec.ts
@@ -112,6 +112,30 @@ test('create() with contact_id on nested companions', async () => {
   })
 })
 
+test('create() with contact_code', async () => {
+  guest.create({ status: 'confirmed', contact_code: 'QOI1U9GX' })
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith('/events/event-uuid/guests', {
+    method: 'post',
+    body: '{"status":"confirmed","contact_code":"QOI1U9GX"}',
+  })
+})
+
+test('create() with contact_code on nested companions', async () => {
+  guest.create({
+    status: 'confirmed',
+    contact_code: 'QOI1U9GX',
+    companions: [{ contact_code: 'IJKL9012' }],
+  })
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith('/events/event-uuid/guests', {
+    method: 'post',
+    body: '{"status":"confirmed","contact_code":"QOI1U9GX","companions":[{"contact_code":"IJKL9012"}]}',
+  })
+})
+
 test('createCompanion()', async () => {
   guest.createCompanion('guest-code', { a: 'b' })
 

--- a/tests/resources/GuestManager.spec.ts
+++ b/tests/resources/GuestManager.spec.ts
@@ -70,6 +70,16 @@ test('create() with contact_id', async () => {
   })
 })
 
+test('create() with contact_code', async () => {
+  guestManager.create({ status: 'confirmed', contact_code: 'QOI1U9GX' })
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith('/events/event-uuid/guests', {
+    method: 'post',
+    body: '{"status":"confirmed","contact_code":"QOI1U9GX","role":"guest_manager"}',
+  })
+})
+
 test('update()', async () => {
   guestManager.update('guest-code', { a: 'b' })
 


### PR DESCRIPTION
Mirrors core [airlst/core#5542](https://github.com/airlst/core/pull/5542). Follow-up to the `contact_id` support released in `0.0.24-beta8` ([#136](https://github.com/airlst/sdk-js/pull/136)).

## Why

`contact_id` alone did not unblock the Sonepar portal: it authenticates a contact **by code** and the API never returned an `id`, so it had nothing to send and fell back to the nested `contact` object — duplicating the contact on every registration, the exact thing `contact_id` was added to prevent. Core now accepts `contact_code` and returns `id` on contact responses.

## Changes

**`contact_code`** sits next to `contact_id` on `CreateMainBodyInterface` and on the nested companion body. Both are accepted only by `POST /events/{event}/guests`, so `CreateRecommendationBodyInterface` now subtracts all three of `contact_id`, `contact_code` and `companions`. `GuestManager.create()` posts to that same endpoint and accepts both identifiers.

**`ContactInterface` gains `id`**, and every field on it becomes **optional**. That interface doubles as a request body (guest create/update, `Contact.update()`) and the API treats all its fields as nullable, so requiring them meant a partial contact object did not typecheck — the `create()` example in this very README was one such case. Widening required → optional is non-breaking for callers.

| Method | `contact_id` / `contact_code` |
|---|---|
| `Guest.create()` (main + `companions[]`) | ✅ |
| `GuestManager.create()` | ✅ |
| `Guest.createCompanion()` | ❌ |
| `Guest.createRecommendation()` | ❌ |

Scope verified against core rather than the spec: `grep -rn contact_code app/Domain/*/Http/Requests/` hits only `StoreGuestsRequest`, and nothing was added to the shared `ContactPayload` / `CompanionGuestPayload` schemas.

## Verification

`yarn run check`, `yarn run test --run` (74 passed), `yarn run build` — all clean.

The `Omit`s cannot be covered by the suite (`tsconfig.json` includes only `src/**/*`, vitest does not typecheck), so they were verified with a throwaway `tsc --noEmit` that exited 0 with four `@ts-expect-error` directives — proving both directions at once, since an unused directive is itself an error:

- compiles: both identifiers on `create()`, on nested companions, on `GuestManager.create()`, and a partial `contact` object
- rejected: `contact_code` and `contact_id` on `createRecommendation()`, `contact_code` on `createCompanion()`, `companions` on `GuestManager.create()`

## Release

Version `0.0.24-beta9` → **`0.0.24-beta10`**. `origin/master`, the latest GitHub release and `npm dist-tags` all agreed on beta9, and it is a pre-release, so the beta counter increments.

**Do not merge before core#5542 is deployed** — the SDK would otherwise advertise fields the live API does not validate, which silently duplicates contacts instead of erroring. After merge, cut the release with `--prerelease`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)