### PR TITLE
feat(bookables): accept reservation extended_fields and date-less FIXED reservations (AIRLST-5301)

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,9 +421,16 @@ const { data } = await new Bookable('event-uuid').createReservation('bookable-gr
     guest_code: 'guest-code',
     reservations: [
       {
+        bookable_id: 'bookable-object-uuid',
+        // Required unless the bookable is an add-on with a FIXED availability type, which has no
+        // date window. For those, omit both — any dates sent are ignored and the reservation is
+        // stored without them.
         starts_at: '2025-02-04 13:20:00',
         ends_at: '2025-02-04 13:40:00',
-        bookable_id: 'bookable-object-uuid'
+        quantity: 1,
+        // Reservation-scoped extended fields, keyed by field key. Only keys defined on the
+        // bookable group for the `bookableReservation` model are accepted.
+        extended_fields: { test_field: 'probeA123' }
       }
     ]
 })
@@ -474,7 +481,12 @@ const { data } = await new Bookable('event-uuid').addOrderLineItem('order-uuid',
   // Required unless the add-on has a FIXED availability type
   start_at: '2026-06-03',
   end_at: '2026-06-06',
-  quantity: 1
+  quantity: 1,
+  // Reservation-scoped extended fields, keyed by field key. Only keys defined on the add-on's
+  // bookable group for the `bookableReservation` model are accepted, and each value is validated
+  // against its field definition. For NIGHTS add-ons the values are written to every per-night
+  // reservation.
+  extended_fields: { test_field: 'probeA123' }
 })
 // data.reservation_ids => ['reservation-uuid', ...]
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airlst/sdk",
-  "version": "0.0.24-beta10",
+  "version": "0.0.24-beta11",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/airlst/sdk-js.git"

--- a/src/resources/Bookable.ts
+++ b/src/resources/Bookable.ts
@@ -160,9 +160,19 @@ interface ListAvailabilitiesResponseInterface {
 interface CreateReservationInterface {
   guest_code: string
   reservations: Array<{
-    starts_at: string
-    ends_at: string
     bookable_id: string
+    /**
+     * Required unless the bookable is an add-on with a FIXED availability type, which has no
+     * date window — for those the reservation is stored without dates.
+     */
+    starts_at?: string
+    ends_at?: string
+    quantity?: number
+    /**
+     * Reservation-scoped extended field values, keyed by field key. Only keys defined on the
+     * bookable group for the `bookableReservation` model are accepted.
+     */
+    extended_fields?: object
   }>
 }
 
@@ -182,6 +192,13 @@ interface AddOrderLineItemInterface {
   start_at?: string
   end_at?: string
   quantity: number
+  /**
+   * Reservation-scoped extended field values, keyed by field key. Only keys defined on the
+   * add-on's bookable group for the `bookableReservation` model are accepted, and each value is
+   * validated against its field definition. For NIGHTS add-ons the values are written to every
+   * per-night reservation.
+   */
+  extended_fields?: object
 }
 
 interface CreateOrderResponseInterface {

--- a/tests/resources/Bookable.spec.ts
+++ b/tests/resources/Bookable.spec.ts
@@ -91,6 +91,29 @@ test('createReservation()', async () => {
   )
 })
 
+test('createReservation() without dates for a FIXED bookable', async () => {
+  const requestBody = {
+    guest_code: 'ABC123',
+    reservations: [
+      {
+        bookable_id: '68076f81-4598-8009-b047-82e482892527',
+        quantity: 1,
+        extended_fields: { test_field: 'probeA123' },
+      },
+    ],
+  }
+  await bookable.createReservation('bookable-group-uuid', requestBody)
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith(
+    '/events/event-uuid/bookables/groups/bookable-group-uuid/reservations',
+    {
+      method: 'post',
+      body: JSON.stringify(requestBody),
+    },
+  )
+})
+
 test('deleteReservation()', async () => {
   await bookable.deleteReservation('guest-code', 'reservation-uuid')
 
@@ -141,6 +164,25 @@ test('addOrderLineItem()', async () => {
     start_at: '2026-06-03',
     end_at: '2026-06-06',
     quantity: 1,
+  }
+  await bookable.addOrderLineItem('order-uuid', requestBody)
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith(
+    '/events/event-uuid/bookables/orders/order-uuid/line-items',
+    {
+      method: 'post',
+      body: JSON.stringify(requestBody),
+    },
+  )
+})
+
+test('addOrderLineItem() with reservation extended_fields', async () => {
+  const requestBody = {
+    guest_code: 'ABC123',
+    addon_id: '68076f81-4598-8009-b047-82e482892527',
+    quantity: 1,
+    extended_fields: { test_field: 'probeA123' },
   }
   await bookable.addOrderLineItem('order-uuid', requestBody)
 


### PR DESCRIPTION
Mirrors [airlst/core#5546](https://github.com/airlst/core/pull/5546) (AIRLST-5301).

## Why

Reservation-scoped `extended_fields` had **no working write path for FIXED add-ons** — the line-item endpoint silently ignored the field, and the reservations endpoint could not create FIXED reservations at all (500 without dates, false "already reserved" 422 with them). Core fixed both; this exposes them.

## What changed

**`addOrderLineItem()`** — new optional `extended_fields`:

```ts
await new Bookable('event-uuid').addOrderLineItem('order-uuid', {
  guest_code: 'ABC123',
  addon_id: 'addon-uuid',
  quantity: 1,
  extended_fields: { test_field: 'probeA123' },
})
```

Only keys defined on the add-on's bookable group for the `bookableReservation` model are accepted, and each value is validated server-side against its field definition. For NIGHTS add-ons the values are written to every per-night reservation.

**`createReservation()`** — `starts_at` / `ends_at` are now **optional per entry**. FIXED add-ons have no date window, so for those the reservation is stored without dates and any dates sent are ignored. Also exposes `quantity` and the reservation-scoped `extended_fields` this endpoint already accepted but the SDK never typed.

Widening the two dates from required to optional is non-breaking for existing callers.

## Endpoint scope

| Endpoint | `extended_fields`? |
|---|---|
| `POST /events/{event}/bookables/orders/{order}/line-items` | ✅ added |
| `POST /events/{event}/bookables/groups/{group}/reservations` | ✅ typed (server already accepted it) |
| `POST /api/checkout/order/{order}/guest/{guest}/addons` | ❌ **deliberately not** |

The checkout add-ons endpoint is a sibling that takes the same core action chain, but its `AddAddonRequest` does not validate `extended_fields` — advertising it there would silently drop the values. Left out on purpose.

## Verification

- `yarn run check` — clean
- `yarn run test --run` — 76 passed (9 files), including two new Bookable specs covering the date-less FIXED payload and the line-item `extended_fields` payload
- `yarn run build` — clean; `dist/resources/Bookable.d.ts` confirms the optional fields
- Throwaway `tsc --noEmit --strict` run (deleted after) proving both directions: the new payloads compile, while `quantity` on the line-item body and `bookable_id` on a reservation entry are still enforced — both `@ts-expect-error` directives were consumed

Version bumped `0.0.24-beta10` → `0.0.24-beta11`.

## ⚠️ Do not merge before core #5546 is deployed

Until then the live API will not validate or persist `extended_fields` on the line-item endpoint, so a caller using it would get a silent wrong result rather than an error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)