### PR TITLE
feat(bookables): surface per_item_price and per_duration_price on availability (AIRLST-5304)

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -184,6 +184,13 @@ export interface AvailabilityInterface {
   per_night_total_capacity: Record<string, Record<string, number>> | null
   per_night_remaining_capacity: Record<string, Record<string, number>> | null
   per_night_price: Record<string, Record<string, PriceInterface>> | null
+  /** Quantity-based (FIXED) bookables only: price per item, keyed by guest group. */
+  per_item_price: Record<string, PriceInterface> | null
+  /**
+   * Slot-based (FLEXIBLE with a slot length) bookables only: price per slot, keyed by guest group
+   * and then by the slot length in minutes. The price does not scale with the slot length.
+   */
+  per_duration_price: Record<string, Record<string, PriceInterface>> | null
   buffer_time: number
   min: number
   max: number


### PR DESCRIPTION
Type companion to airlst/core#5557, which publishes the quantity-based and slot-based prices on the Suite API availability endpoint alongside the existing `per_night_price`.

## What

Two fields on `AvailabilityInterface`, reusing the existing `PriceInterface`:

```ts
per_item_price: Record<string, PriceInterface> | null
per_duration_price: Record<string, Record<string, PriceInterface>> | null
```

- `per_item_price` — quantity-based (FIXED) bookables. Keyed by guest group only; the price is per item.
- `per_duration_price` — slot-based (FLEXIBLE with a slot length) bookables. Keyed by guest group, then by the slot length in minutes. The price is per slot and does not scale with the length.

Both are `null` for bookables of a different pricing model, same as `per_night_price` is for non-accommodation bookables. Values are minor units, gross incl. VAT.

Same shape as the `per_night_price` addition in #135, so no change to `Bookable.ts` or any call site.

## Verification

`yarn build`, `yarn lint`, and `yarn vitest run` (76 tests) all pass.

Merge after airlst/core#5557.

🤖 Generated with [Claude Code](https://claude.com/claude-code)