### PR TITLE
feat(bookables): accept line_items array on addOrderLineItem and expose slot config (AIRLST-5303)

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,17 @@ const { data } = await new Bookable('event-uuid').listAvailabilities('bookable-g
 })
 ```
 
+For a slot-based FLEXIBLE bookable, each availability also carries the slot configuration so you can
+derive the bookable slots yourself: starting at the event-local `starts_at` time of day, step
+`duration_minutes + buffer_minutes` until the window closes; each slot covers
+`[slot_start, slot_start + duration_minutes)` and seats `capacity_per_slot` units. A window whose
+closing time is not after its opening time (e.g. 22:00–06:00, or 00:00–00:00 for 24/7) runs past
+midnight, and every day of the availability repeats the full window. Book each slot as its own
+`line_items` entry via `addOrderLineItem()`.
+
+`duration_minutes` is the mode signal — it is `null` for every non-slot availability. Do not detect
+slot mode from `buffer_minutes` or `capacity_per_slot`: those always carry their defaults (`0` / `1`).
+
 #### Create reservation
 
 ```javascript
@@ -470,25 +481,58 @@ import { Bookable } from '@airlst/sdk'
 const { data } = await new Bookable('event-uuid').getOrder('order-uuid')
 ```
 
-#### Add an add-on allocation line item to a carrier order
+#### Add add-on allocation line items to a carrier order
+
+Pass `line_items` to allocate any number of add-ons in one request. Entries are independent, so a
+single call can book several slots of a slot-based FLEXIBLE add-on (e.g. 20 hourly shifts of stand
+security), book non-contiguous slots, mix different add-ons and use a different quantity per entry.
+
+The payload is applied all-or-nothing: if any entry is invalid or unavailable, nothing is held and
+the request fails with 422 naming the rejected entry (`Line item 1: …`). At most 50 entries per
+request.
 
 ```javascript
 import { Bookable } from '@airlst/sdk'
 
 const { data } = await new Bookable('event-uuid').addOrderLineItem('order-uuid', {
   guest_code: 'guest-code',
-  addon_id: 'addon-uuid',
-  // Required unless the add-on has a FIXED availability type
-  start_at: '2026-06-03',
-  end_at: '2026-06-06',
-  quantity: 1,
-  // Reservation-scoped extended fields, keyed by field key. Only keys defined on the add-on's
-  // bookable group for the `bookableReservation` model are accepted, and each value is validated
-  // against its field definition. For NIGHTS add-ons the values are written to every per-night
-  // reservation.
-  extended_fields: { test_field: 'probeA123' }
+  line_items: [
+    {
+      addon_id: 'addon-uuid',
+      // Required unless the add-on has a FIXED availability type. For a slot-based FLEXIBLE add-on
+      // these must be the boundaries of one slot — a range spanning several slots is rejected, so
+      // send one entry per slot. Read duration_minutes / buffer_minutes / capacity_per_slot from
+      // listAvailabilities() to work out the slots.
+      start_at: '2026-06-03T09:00:00Z',
+      end_at: '2026-06-03T10:00:00Z',
+      quantity: 1
+    },
+    {
+      addon_id: 'addon-uuid',
+      start_at: '2026-06-03T10:00:00Z',
+      end_at: '2026-06-03T11:00:00Z',
+      quantity: 1,
+      // Reservation-scoped extended fields, keyed by field key. Only keys defined on the add-on's
+      // bookable group for the `bookableReservation` model are accepted, and each value is validated
+      // against its field definition. For NIGHTS add-ons the values are written to every per-night
+      // reservation.
+      extended_fields: { test_field: 'probeA123' }
+    }
+  ]
 })
-// data.reservation_ids => ['reservation-uuid', ...]
+// data.reservation_ids => ['reservation-uuid', ...] (flat, in submission order)
+// data.line_items => [{ index: 0, reservation_ids: [...] }, { index: 1, reservation_ids: [...] }]
+```
+
+The previous single-item body (`addon_id` / `start_at` / `end_at` / `quantity` / `extended_fields` at
+the top level) still works unchanged, but is deprecated in favour of `line_items`:
+
+```javascript
+const { data } = await new Bookable('event-uuid').addOrderLineItem('order-uuid', {
+  guest_code: 'guest-code',
+  addon_id: 'addon-uuid',
+  quantity: 1
+})
 ```
 
 #### Delete an add-on allocation line item and release its contingent

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airlst/sdk",
-  "version": "0.0.24-beta11",
+  "version": "0.0.24-beta12",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/airlst/sdk-js.git"

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -187,6 +187,22 @@ export interface AvailabilityInterface {
   buffer_time: number
   min: number
   max: number
+  /**
+   * Slot-based (FLEXIBLE) configuration. Derive the bookable slots from it: starting at the
+   * event-local `starts_at` time of day, step `duration_minutes + buffer_minutes` until the window
+   * closes; each slot covers `[slot_start, slot_start + duration_minutes)` and seats
+   * `capacity_per_slot` units. A window whose closing time is not after its opening time (e.g.
+   * 22:00–06:00, or 00:00–00:00 for 24/7) runs past midnight, and every day of the availability
+   * repeats the full window. Book each slot as its own `line_items` entry via `addOrderLineItem()`.
+   *
+   * `duration_minutes` is the mode signal — it is null for every non-slot availability (including
+   * legacy free-duration FLEXIBLE, which uses `min` / `max` / `buffer_time` above).
+   * `buffer_minutes` and `capacity_per_slot` always carry their column defaults (0 / 1) and say
+   * nothing about the mode, so do not detect slot mode from them.
+   */
+  duration_minutes: number | null
+  buffer_minutes: number | null
+  capacity_per_slot: number | null
 }
 
 export interface ImportableFieldInterface {

--- a/src/resources/Bookable.ts
+++ b/src/resources/Bookable.ts
@@ -186,10 +186,16 @@ interface CreateOrderInterface {
   booking_id: string
 }
 
-interface AddOrderLineItemInterface {
-  guest_code: string
+interface OrderLineItemInterface {
+  /** Must belong to a bookable group of this event. */
   addon_id: string
+  /**
+   * Required unless the add-on has a FIXED availability type, which has no date window. For a
+   * slot-based FLEXIBLE add-on this must be the start of one slot — a range spanning several slots
+   * is rejected, so send one entry per slot.
+   */
   start_at?: string
+  /** Required unless the add-on has a FIXED availability type. Must be the end of the same slot. */
   end_at?: string
   quantity: number
   /**
@@ -200,6 +206,31 @@ interface AddOrderLineItemInterface {
    */
   extended_fields?: object
 }
+
+/**
+ * Allocates one or more add-ons in a single request. Entries are independent, so one call may book
+ * several slots of a slot-based FLEXIBLE add-on (e.g. 20 hourly shifts), book non-contiguous slots,
+ * mix different add-ons and use a different quantity per entry.
+ *
+ * The payload is applied all-or-nothing: if any entry is invalid or unavailable, nothing is held and
+ * the 422 names the rejected entry ("Line item {index}: …"). At most 50 entries per request.
+ */
+interface AddOrderLineItemsInterface {
+  guest_code: string
+  line_items: Array<OrderLineItemInterface>
+}
+
+/**
+ * @deprecated Single-item body kept for backwards compatibility. Pass `line_items` instead — it
+ * accepts the same fields per entry and allocates any number of them in one request.
+ */
+interface AddOrderLineItemLegacyInterface extends OrderLineItemInterface {
+  guest_code: string
+}
+
+type AddOrderLineItemInterface =
+  | AddOrderLineItemsInterface
+  | AddOrderLineItemLegacyInterface
 
 interface CreateOrderResponseInterface {
   data: OrderInterface
@@ -215,7 +246,17 @@ interface ShowOrderResponseInterface {
 
 interface AddOrderLineItemResponseInterface {
   data: {
+    /**
+     * Every created reservation id, flat and in submission order. An entry contributes more than one
+     * id when the add-on fans out (NIGHTS: one reservation per night).
+     */
     reservation_ids: Array<string>
+    /** The created reservations grouped by the submitted entry they belong to. */
+    line_items: Array<{
+      /** Position of the entry in the submitted `line_items` array. */
+      index: number
+      reservation_ids: Array<string>
+    }>
   }
 }
 

--- a/tests/resources/Bookable.spec.ts
+++ b/tests/resources/Bookable.spec.ts
@@ -196,6 +196,56 @@ test('addOrderLineItem() with reservation extended_fields', async () => {
   )
 })
 
+test('addOrderLineItem() with several line_items in one request', async () => {
+  const requestBody = {
+    guest_code: 'ABC123',
+    line_items: [
+      {
+        addon_id: '68076f81-4598-8009-b047-82e482892527',
+        start_at: '2026-06-03T09:00:00Z',
+        end_at: '2026-06-03T10:00:00Z',
+        quantity: 1,
+      },
+      {
+        addon_id: '68076f81-4598-8009-b047-82e482892527',
+        start_at: '2026-06-03T10:00:00Z',
+        end_at: '2026-06-03T11:00:00Z',
+        quantity: 2,
+        extended_fields: { guard_name: 'Late shift' },
+      },
+    ],
+  }
+  await bookable.addOrderLineItem('order-uuid', requestBody)
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith(
+    '/events/event-uuid/bookables/orders/order-uuid/line-items',
+    {
+      method: 'post',
+      body: JSON.stringify(requestBody),
+    },
+  )
+})
+
+test('addOrderLineItem() with line_items for a FIXED add-on omits the dates', async () => {
+  const requestBody = {
+    guest_code: 'ABC123',
+    line_items: [
+      { addon_id: '68076f81-4598-8009-b047-82e482892527', quantity: 3 },
+    ],
+  }
+  await bookable.addOrderLineItem('order-uuid', requestBody)
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith(
+    '/events/event-uuid/bookables/orders/order-uuid/line-items',
+    {
+      method: 'post',
+      body: JSON.stringify(requestBody),
+    },
+  )
+})
+
 test('deleteOrderLineItem()', async () => {
   await bookable.deleteOrderLineItem('order-uuid', 'line-item-uuid')
 


### PR DESCRIPTION
Mirrors [airlst/core#5553](https://github.com/airlst/core/pull/5553) (AIRLST-5303). Version bumped `0.0.24-beta11` → `0.0.24-beta12`.

## What changed

**`addOrderLineItem()` — `POST /events/{event}/bookables/orders/{order}/line-items`**

Now accepts an array, so booking N slots of a slot-based FLEXIBLE add-on (e.g. 20 hourly shifts of stand security) is one request instead of N:

```ts
await new Bookable(eventId).addOrderLineItem(orderId, {
  guest_code: 'ABC123',
  line_items: [
    { addon_id, start_at: '2026-06-03T09:00:00Z', end_at: '2026-06-03T10:00:00Z', quantity: 1 },
    { addon_id, start_at: '2026-06-03T10:00:00Z', end_at: '2026-06-03T11:00:00Z', quantity: 2 },
  ],
})
```

Entries are independent — one call may book non-contiguous slots, mix different add-ons, and use a different `quantity` / `extended_fields` per entry. Applied all-or-nothing; at most 50 entries.

The body type is a union of the bulk and legacy shapes, so **the previous single-item body still compiles and behaves identically**. The flat shape is marked `@deprecated` to steer new code to `line_items`.

The response gains `data.line_items` (`{ index, reservation_ids }[]`), mapping reservations back to the submitted entry — useful because an entry fans out to several reservations for a NIGHTS add-on. `data.reservation_ids` is unchanged: flat, in submission order.

**`AvailabilityInterface` — `POST .../objects/{bookable}/availability`**

Gains `duration_minutes`, `buffer_minutes`, `capacity_per_slot` (all `number | null`). Without these a consumer cannot derive the slot boundaries it now has to enumerate. `duration_minutes` is the mode signal — null for every non-slot availability; the other two always carry their column defaults (`0` / `1`), so detecting slot mode from them misreads every non-slot availability. The docblock and README say so explicitly.

## Scope — endpoints deliberately not touched

`line_items` is declared inline on `AddOrderLineItemRequest` in core, not in a shared rule builder, so it is **this endpoint only**. Specifically **not** accepted on:

- `createReservation()` (`POST .../groups/{group}/reservations`) — already takes its own `reservations: [...]` array and is the non-order path
- `assignBookables()` (`POST .../bookables/assignments`) — has its own `selected_slots` array, async
- `POST /checkout/order/{order}/guest/{guest}/addons` — not in this SDK; keeps single-entry semantics in core

There is no `extends` chain on `AddOrderLineItemInterface`, so nothing leaks onto sibling endpoints.

## Verification

- `yarn run check` clean, `yarn run test --run` → **78 tests pass** (2 new specs for the bulk and FIXED-add-on shapes), `yarn run build` clean
- Type-level check the specs cannot cover (unions/negatives), via a throwaway `tsc --noEmit --strict` probe with `@ts-expect-error` on what must fail — exit 0 proves both directions: bulk shape compiles, legacy flat shape still compiles, an entry missing `quantity` fails, a payload with neither shape fails, a bogus field inside an entry fails, and `data.reservation_ids` / `data.line_items` / the availability slot fields are reachable and correctly nullable
- Confirmed in `dist/resources/Bookable.d.ts` that the union and the `@deprecated` marker survive into the published types

Known and harmless: a payload carrying *both* shapes typechecks, because TS union excess-property checking permits properties present in any member. That matches the API, where `line_items` wins and the flat keys are ignored.

## Do not merge yet

Core #5553 is not merged or deployed. Merging this first would advertise `line_items` against an API that still rejects it. No release until core is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)