### PR TITLE
chore(release): 0.0.24-beta13 with the availability price fields (AIRLST-5304)

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,21 @@ midnight, and every day of the availability repeats the full window. Book each s
 `duration_minutes` is the mode signal — it is `null` for every non-slot availability. Do not detect
 slot mode from `buffer_minutes` or `capacity_per_slot`: those always carry their defaults (`0` / `1`).
 
+Each availability also carries the price for its own pricing model, so you never have to hardcode a
+price in the frontend. At most one of the three fields is populated; the others are `null`:
+
+| Field | Populated for | Shape |
+| --- | --- | --- |
+| `per_item_price` | quantity-based (FIXED) | `{ [guestGroupId]: Price }` — per item, multiply by the quantity |
+| `per_duration_price` | slot-based (FLEXIBLE with `duration_minutes`) | `{ [guestGroupId]: { [minutes]: Price } }` — per slot; does **not** scale with the slot length |
+| `per_night_price` | per-night (NIGHTS) | `{ [guestGroupId]: { [YYYY-MM-DD]: Price } }` — per night, sum the stay |
+
+`net`, `gross` and `vat` are integers in minor units (cents) with `gross` inclusive of VAT, and
+`vat_rate` is a percentage. The outer key is the availability's own guest group, or
+`00000000-0000-0000-0000-000000000000` for a row that applies to every group without a specific
+price. A legacy FLEXIBLE availability with no `duration_minutes` has no per-duration price and
+reports `null`.
+
 #### Create reservation
 
 ```javascript

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airlst/sdk",
-  "version": "0.0.24-beta12",
+  "version": "0.0.24-beta13",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/airlst/sdk-js.git"


### PR DESCRIPTION
Follow-up to #140 (AIRLST-5304). Needed because that PR shipped no version bump.

## Why

#140 merged at 13:53:59Z, but `0.0.24-beta12` had already been released at 13:28:40Z (from #141). So `per_item_price` / `per_duration_price` are on `master` but **not in any published package**:

```
$ npm pack @airlst/sdk@0.0.24-beta12 && grep -c per_item_price package/dist/interfaces.d.ts
0
```

Consumers on the current `latest` still cannot see either field.

## What

- **`package.json` → `0.0.24-beta13`** (pre-release, so the beta counter increments per the release table).
- **README**: document the three availability price fields, which #140 omitted even though the README already documents the neighbouring slot configuration. Covers which pricing model populates each field, the shapes, that at most one is ever populated, and that values are integer minor units keyed by guest group (with the null-UUID default row).

No type or runtime change — `src/interfaces.ts` already has the fields from #140. `AvailabilityInterface` is a response type used only by `Bookable.listAvailabilities()`, so there is no `extends` / `Omit` chain to re-scope.

## Verification

`yarn run check`, `yarn run test --run` (78 tests) and `yarn run build` all pass. Confirmed the built `dist/interfaces.d.ts` carries both fields.

Core side (`per_item_price` / `per_duration_price` on the availability endpoint) is merged: airlst/core#5557.

After merge, cut the `0.0.24-beta13` release with `--prerelease` to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)