### PR TITLE
feat(bookables): expose the event timezone and correct the slot-derivation contract (AIRLST-5311)

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,13 +412,22 @@ const { data } = await new Bookable('event-uuid').listAvailabilities('bookable-g
 })
 ```
 
+Every datetime in the response is an **absolute UTC instant**, never event-local wall clock. The
+response publishes the event timezone as `data.timezone` (e.g. `Europe/Berlin`) — the same value is
+also on `EventInterface` — so you can render those instants and convert a wall-clock time picked by a
+user back to UTC without a second request.
+
 For a slot-based FLEXIBLE bookable, each availability also carries the slot configuration so you can
-derive the bookable slots yourself: starting at the event-local `starts_at` time of day, step
-`duration_minutes + buffer_minutes` until the window closes; each slot covers
+derive the bookable slots yourself: convert `starts_at` into `data.timezone`, step
+`duration_minutes + buffer_minutes` in that local wall clock until the window closes, then convert
+each slot boundary back to UTC — which is how the server generates them. Each slot covers
 `[slot_start, slot_start + duration_minutes)` and seats `capacity_per_slot` units. A window whose
 closing time is not after its opening time (e.g. 22:00–06:00, or 00:00–00:00 for 24/7) runs past
 midnight, and every day of the availability repeats the full window. Book each slot as its own
 `line_items` entry via `addOrderLineItem()`.
+
+> Step in local time, not in UTC. Across a DST transition inside the window, consecutive slots are
+> **not** a fixed number of UTC minutes apart, so a UTC-stepped grid diverges from the server's.
 
 `duration_minutes` is the mode signal — it is `null` for every non-slot availability. Do not detect
 slot mode from `buffer_minutes` or `capacity_per_slot`: those always carry their defaults (`0` / `1`).
@@ -505,6 +514,12 @@ security), book non-contiguous slots, mix different add-ons and use a different 
 The payload is applied all-or-nothing: if any entry is invalid or unavailable, nothing is held and
 the request fails with 422 naming the rejected entry (`Line item 1: …`). At most 50 entries per
 request.
+
+`start_at` and `end_at` are **absolute instants**, never event-local wall clock. Send UTC (`…Z`) or an
+explicit offset (`2026-06-03T11:00:00+02:00`), which is stored as the same instant; a value carrying
+no zone at all is read as UTC. To book a wall-clock time, convert it from the event timezone first —
+`listAvailabilities()` returns it as `data.timezone`. Sending `23:00` for a 23:00 event-local slot in
+a UTC+2 event books a different slot, or none.
 
 ```javascript
 import { Bookable } from '@airlst/sdk'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airlst/sdk",
-  "version": "0.0.24-beta13",
+  "version": "0.0.24-beta14",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/airlst/sdk-js.git"

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -6,6 +6,14 @@ export interface EventInterface {
   default_locale: LocaleInterface
   additional_locales: Array<LocaleInterface>
   registration_type: string
+  /**
+   * IANA identifier of the event timezone, e.g. `Europe/Berlin`.
+   *
+   * Every datetime the API emits and accepts is an absolute UTC instant, never event-local wall
+   * clock. This is what to render those instants in, and what to convert a wall-clock time picked
+   * by a user *from* before sending it back (AIRLST-5311).
+   */
+  timezone: string
 }
 
 interface LocaleInterface {
@@ -179,7 +187,12 @@ export interface PriceInterface {
 }
 
 export interface AvailabilityInterface {
+  /**
+   * Absolute UTC instant (`2030-06-03T07:00:00.000000Z`), never event-local wall clock. Render it in
+   * the event timezone, which `listAvailabilities()` returns as `data.timezone` (AIRLST-5311).
+   */
   starts_at: string
+  /** Absolute UTC instant. Same semantics as `starts_at`. */
   ends_at: string
   per_night_total_capacity: Record<string, Record<string, number>> | null
   per_night_remaining_capacity: Record<string, Record<string, number>> | null
@@ -195,12 +208,19 @@ export interface AvailabilityInterface {
   min: number
   max: number
   /**
-   * Slot-based (FLEXIBLE) configuration. Derive the bookable slots from it: starting at the
-   * event-local `starts_at` time of day, step `duration_minutes + buffer_minutes` until the window
-   * closes; each slot covers `[slot_start, slot_start + duration_minutes)` and seats
-   * `capacity_per_slot` units. A window whose closing time is not after its opening time (e.g.
-   * 22:00–06:00, or 00:00–00:00 for 24/7) runs past midnight, and every day of the availability
-   * repeats the full window. Book each slot as its own `line_items` entry via `addOrderLineItem()`.
+   * Slot-based (FLEXIBLE) configuration. Derive the bookable slots from it: convert `starts_at` into
+   * the event timezone (`data.timezone` on the same response), step
+   * `duration_minutes + buffer_minutes` in that local wall clock until the window closes, then
+   * convert each slot boundary back to UTC — which is how the server generates them.
+   *
+   * Stepping in UTC instead only agrees with the server while the offset is constant: across a DST
+   * transition inside the window, consecutive slots are NOT a fixed number of UTC minutes apart and
+   * the two grids diverge.
+   *
+   * Each slot covers `[slot_start, slot_start + duration_minutes)` and seats `capacity_per_slot`
+   * units. A window whose closing time is not after its opening time (e.g. 22:00–06:00, or
+   * 00:00–00:00 for 24/7) runs past midnight, and every day of the availability repeats the full
+   * window. Book each slot as its own `line_items` entry via `addOrderLineItem()`.
    *
    * `duration_minutes` is the mode signal — it is null for every non-slot availability (including
    * legacy free-duration FLEXIBLE, which uses `min` / `max` / `buffer_time` above).

--- a/src/resources/Bookable.ts
+++ b/src/resources/Bookable.ts
@@ -146,13 +146,25 @@ interface ListBookablesResponseInterface {
 }
 
 interface ListAvailabilitiesInterface {
+  /**
+   * Start of the window to list availabilities for. An absolute instant: a value without a zone is
+   * read as UTC, not as event-local time.
+   */
   start_date: string
+  /** End of the window. Same instant semantics as `start_date`. */
   end_date: string
   guest_code?: string
 }
 
 interface ListAvailabilitiesResponseInterface {
   data: {
+    /**
+     * IANA identifier of the event timezone, e.g. `Europe/Berlin`. Every `starts_at` / `ends_at` in
+     * `availabilities` — and every slot derived from them — is an absolute UTC instant. This is the
+     * timezone the slot grid was generated in, so a client deriving slots from `duration_minutes`
+     * needs no second request to convert against (AIRLST-5311).
+     */
+    timezone: string
     availabilities: Array<AvailabilityInterface>
   }
 }
@@ -164,8 +176,12 @@ interface CreateReservationInterface {
     /**
      * Required unless the bookable is an add-on with a FIXED availability type, which has no
      * date window — for those the reservation is stored without dates.
+     *
+     * An absolute instant: UTC (`…Z`) or an explicit offset, which is stored as the same instant. A
+     * value carrying no zone is read as UTC, not as event-local wall clock (AIRLST-5311).
      */
     starts_at?: string
+    /** Same instant semantics as `starts_at`. */
     ends_at?: string
     quantity?: number
     /**
@@ -193,9 +209,19 @@ interface OrderLineItemInterface {
    * Required unless the add-on has a FIXED availability type, which has no date window. For a
    * slot-based FLEXIBLE add-on this must be the start of one slot — a range spanning several slots
    * is rejected, so send one entry per slot.
+   *
+   * An **absolute instant**, never event-local wall clock. Send UTC (`2026-06-03T09:00:00Z`) or an
+   * explicit offset (`2026-06-03T11:00:00+02:00`), which is stored as the same instant; a value
+   * carrying no zone at all is read as UTC. To book a wall-clock time, convert it from the event
+   * timezone first — `listAvailabilities()` returns it as `data.timezone`, and it is also on
+   * `EventInterface`. Sending `23:00` for a 23:00 event-local slot in a UTC+2 event books a
+   * different slot, or none (AIRLST-5311).
    */
   start_at?: string
-  /** Required unless the add-on has a FIXED availability type. Must be the end of the same slot. */
+  /**
+   * Required unless the add-on has a FIXED availability type. Must be the end of the same slot.
+   * Same instant semantics as `start_at`.
+   */
   end_at?: string
   quantity: number
   /**

--- a/tests/resources/Bookable.spec.ts
+++ b/tests/resources/Bookable.spec.ts
@@ -46,6 +46,37 @@ test('listAvailabilities()', async () => {
   )
 })
 
+test('listAvailabilities() returns the event timezone alongside the availabilities', async () => {
+  // The availabilities carry UTC instants and the client derives slots from duration_minutes, so the
+  // response publishes the timezone to convert against — no second request needed (AIRLST-5311).
+  apiMock.mockResolvedValueOnce({
+    data: {
+      timezone: 'Europe/Berlin',
+      availabilities: [
+        {
+          starts_at: '2026-07-29T20:00:00.000000Z',
+          ends_at: '2026-07-29T22:00:00.000000Z',
+          duration_minutes: 60,
+          buffer_minutes: 0,
+          capacity_per_slot: 1,
+        },
+      ],
+    },
+  })
+
+  const response = await bookable.listAvailabilities(
+    'bookable-group-uuid',
+    'bookable-object-uuid',
+    { start_date: 'start-date', end_date: 'end-date' },
+  )
+
+  expect(response.data.timezone).toBe('Europe/Berlin')
+  // 20:00Z is 22:00 in Europe/Berlin on a summer day — the instant is untouched by the field.
+  expect(response.data.availabilities[0].starts_at).toBe(
+    '2026-07-29T20:00:00.000000Z',
+  )
+})
+
 test('listAvailabilities() with guest_code', async () => {
   const requestBody = {
     start_date: 'start-date',

--- a/tests/resources/Event.spec.ts
+++ b/tests/resources/Event.spec.ts
@@ -23,6 +23,18 @@ test('get()', async () => {
   expect(apiMock).toHaveBeenCalledWith('/events/abc')
 })
 
+test('get() exposes the event timezone', async () => {
+  // Every datetime the API emits is an absolute UTC instant, so consumers need the event timezone to
+  // render them and to convert a picked wall-clock time back before sending it (AIRLST-5311).
+  apiMock.mockResolvedValueOnce({
+    data: { event: { id: 'abc', timezone: 'Europe/Berlin' } },
+  })
+
+  const response = await event.get('abc')
+
+  expect(response.data.event.timezone).toBe('Europe/Berlin')
+})
+
 test('generateTemporaryUploadUrl()', async () => {
   const signedUrlResponse = {
     data: {


### PR DESCRIPTION
Mirrors [airlst/core#5582](https://github.com/airlst/core/pull/5582) (AIRLST-5311).

## Why

Core keeps every bookable datetime as an absolute UTC instant, but published no timezone to convert against — so consumers had to hardcode one. (A client frontend did exactly that, hardcoding `Europe/Berlin`, which is wrong for any non-German event.) Core now exposes the event timezone; this mirrors it.

## New fields

| Field | Endpoint(s) | Notes |
|---|---|---|
| `EventInterface.timezone` | `Event.get()`, `Event.list()` | Both share `EventApiResource`, so one field covers both. Non-optional: the column is `NOT NULL DEFAULT 'Europe/Berlin'`. |
| `data.timezone` on `listAvailabilities()` | `POST .../availability` | Lets a client derive slots without a second request. |

**Not added anywhere else.** The checkout addon listing also gained a `meta.timezone`, but that endpoint belongs to the landing-page checkout API, which this SDK does not model — there is no `Checkout` resource to put it on. Core's `EventMobileClientResource` gained the field too; that is the mobile/checkin client, also not modelled here.

## The part that actually fixes a bug

`AvailabilityInterface`'s slot-derivation docblock and the matching README section both told consumers to start **"at the event-local `starts_at` time of day"**. `starts_at` is UTC. Anyone who followed that literally shifted every derived slot by the event's offset — which is precisely the symptom AIRLST-5311 was reported for.

Both now say: convert `starts_at` into the timezone, step `duration_minutes + buffer_minutes` in that local wall clock, then convert each boundary back to UTC.

There is a reason it must be done in local time, called out in the docs: across a DST transition inside the window, consecutive slots are **not** a fixed number of UTC minutes apart. A UTC-stepped grid silently diverges from the server's, which generates it in local time for exactly this reason.

## Request-side contract, documented

Core now stores an offset-bearing value as the instant it denotes rather than as its wall-clock hour, so `2026-06-03T11:00:00+02:00` and `2026-06-03T09:00:00Z` are interchangeable, and a value carrying no zone is read as UTC. Documented on `addOrderLineItem()`'s `start_at`/`end_at`, `createReservation()`'s `starts_at`/`ends_at`, and `listAvailabilities()`'s `start_date`/`end_date`. No signature changes — the types were already `string`.

## Verification

- `yarn run check`, `yarn run test --run` (80 pass), `yarn run build` all clean.
- New specs cover `data.timezone` on the availability response and `timezone` on the event response.
- The emitted declarations were inspected (`dist/interfaces.d.ts`, `dist/resources/Bookable.d.ts`) since vitest does not typecheck.
- Field reachability proven with a throwaway `tsc --noEmit --strict` run using `@ts-expect-error` on the negative case — exit 0, so the positive access compiles and `timezone` is genuinely non-optional.

## Merge order

⚠️ **Do not merge before core#5582 is deployed** to the environment consumers hit. Until then the SDK would advertise `timezone` on responses that do not carry it yet — a silent `undefined` rather than an error. Version is bumped to `0.0.24-beta14`; I have not cut the release.
