### PR TITLE
feat(bookable): add bulkDeleteOrderLineItems (AIRLST-5392)

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,22 @@ import { Bookable } from '@airlst/sdk'
 await new Bookable('event-uuid').deleteOrderLineItem('order-uuid', 'line-item-uuid')
 ```
 
+#### Bulk-delete add-on allocation line items in one request
+
+Removes several line items at once. A slot-based add-on holds one line item per slot, so this clears a whole time range in a single call instead of one `deleteOrderLineItem()` per slot. Read the ids from `getOrder()`. Up to 100 ids per request; the call is all-or-nothing.
+
+`deleted_line_item_ids` is the authoritative list of what was removed — it can name more ids than the request when a NIGHTS add-on releases the whole contiguous stay.
+
+```javascript
+import { Bookable } from '@airlst/sdk'
+
+const { data } = await new Bookable('event-uuid').bulkDeleteOrderLineItems('order-uuid', {
+  line_item_ids: ['line-item-uuid-1', 'line-item-uuid-2']
+})
+
+console.log(data.deleted_count, data.deleted_line_item_ids)
+```
+
 #### Bulk-assign an add-on to many guests
 
 Assigns a single add-on selection to many guests at once. Processing is asynchronous, so the call resolves with no content once the batch has been queued.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airlst/sdk",
-  "version": "0.0.24-beta14",
+  "version": "0.0.24-beta15",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/airlst/sdk-js.git"

--- a/src/resources/Bookable.ts
+++ b/src/resources/Bookable.ts
@@ -119,6 +119,19 @@ export const Bookable = class {
     )
   }
 
+  public async bulkDeleteOrderLineItems(
+    orderUuid: string,
+    body: BulkDeleteOrderLineItemsInterface,
+  ): Promise<BulkDeleteOrderLineItemsResponseInterface> {
+    return await Api.sendRequest(
+      `/events/${this.eventId}/bookables/orders/${orderUuid}/line-items/bulk-delete`,
+      {
+        method: 'post',
+        body: JSON.stringify(body),
+      },
+    )
+  }
+
   public async assignBookables(body: AssignBookablesInterface): Promise<void> {
     await Api.sendRequest(`/events/${this.eventId}/bookables/assignments`, {
       method: 'post',
@@ -283,6 +296,29 @@ interface AddOrderLineItemResponseInterface {
       index: number
       reservation_ids: Array<string>
     }>
+  }
+}
+
+interface BulkDeleteOrderLineItemsInterface {
+  /**
+   * The line items to delete, 1–100 unique ids, each belonging to this order. Read them from
+   * `getOrder()`, whose `line_items` carry the `id`, `option_from` and `option_to` to pick a range
+   * against. Use this instead of one `deleteOrderLineItem()` call per slot to clear a whole time
+   * range at once.
+   */
+  line_item_ids: Array<string>
+}
+
+interface BulkDeleteOrderLineItemsResponseInterface {
+  data: {
+    /**
+     * Every deleted line item id. Names more ids than the request when a NIGHTS add-on releases the
+     * whole contiguous stay one of the ids belonged to, so this — not the request — is the
+     * authoritative list of what was removed.
+     */
+    deleted_line_item_ids: Array<string>
+    /** Number of entries in `deleted_line_item_ids`. */
+    deleted_count: number
   }
 }
 

--- a/tests/resources/Bookable.spec.ts
+++ b/tests/resources/Bookable.spec.ts
@@ -289,6 +289,22 @@ test('deleteOrderLineItem()', async () => {
   )
 })
 
+test('bulkDeleteOrderLineItems()', async () => {
+  const requestBody = {
+    line_item_ids: ['line-item-uuid-1', 'line-item-uuid-2'],
+  }
+  await bookable.bulkDeleteOrderLineItems('order-uuid', requestBody)
+
+  expect(apiMock).toHaveBeenCalledTimes(1)
+  expect(apiMock).toHaveBeenCalledWith(
+    '/events/event-uuid/bookables/orders/order-uuid/line-items/bulk-delete',
+    {
+      method: 'post',
+      body: JSON.stringify(requestBody),
+    },
+  )
+})
+
 test('assignBookables()', async () => {
   const requestBody = {
     guests: ['ABCD1234', 'ABCD2345'],


### PR DESCRIPTION
## What

Adds `Bookable.bulkDeleteOrderLineItems(orderUuid, body)` for the new Event API endpoint:

```
POST /events/{event}/bookables/orders/{order}/line-items/bulk-delete
```

- **Body:** `{ line_item_ids: string[] }` — 1–100 unique ids, each belonging to the order.
- **Returns:** `{ data: { deleted_line_item_ids: string[], deleted_count: number } }`.

## Why

A slot-based `FLEXIBLE` add-on holds one line item per slot, so clearing a whole time range (e.g. a full day of hourly slots) meant one `deleteOrderLineItem()` call per slot. This removes them in a single request. Read the ids from `getOrder()`.

`deleted_line_item_ids` is authoritative — it can name **more** ids than the request when a NIGHTS add-on releases the whole contiguous stay one of the ids belonged to.

## Scope

The endpoint has its own request class in core (`line_item_ids` only) — it is **not** a shared schema, so no other SDK method or interface is affected. The single-item `deleteOrderLineItem()` is unchanged.

## Changes

- `src/resources/Bookable.ts` — method + `BulkDeleteOrderLineItemsInterface` / `BulkDeleteOrderLineItemsResponseInterface`.
- `tests/resources/Bookable.spec.ts` — asserts the POST path and JSON body.
- `README.md` — usage section.
- `package.json` — bump `0.0.24-beta14` → `0.0.24-beta15`.

`yarn run check`, `yarn run test --run` (81 pass) and `yarn run build` all pass; emitted `dist/resources/Bookable.d.ts` carries the new method.

## Release

Core PR: airlst/core#5613. **Do not release until the core change is deployed** to the target environment — I'll cut the `0.0.24-beta15` GitHub release after both merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)